### PR TITLE
Remove oaicite contentReference tags

### DIFF
--- a/include/hexapod_locomotion_system.h
+++ b/include/hexapod_locomotion_system.h
@@ -90,12 +90,12 @@ struct HexapodParameters {
         float pos_threshold_mm = 0.5f; //   ”      ”
         bool use_damping = true;
         float damping_lambda = 30.0f; // λ ≈ 30mm  (see paper)
-        bool clamp_joints = true;     // ik_clamp_joints :contentReference[oaicite:0]{index=0}
+        bool clamp_joints = true;     // ik_clamp_joints
     } ik;
 
     // Parametros de compensación del cuerpo
     struct BodyCompConfig {
-        bool enable = true;         // “IMU body compensation” :contentReference[oaicite:1]{index=1}
+        bool enable = true;         // “IMU body compensation”
         float kp = 0.6f;            // same order as OpenSHC demos
         float lp_alpha = 0.10f;     // 1-pole low-pass
         float max_tilt_deg = 12.0f; // disable beyond this (OpenSHC default)

--- a/src/hexapod_locomotion_system.cpp
+++ b/src/hexapod_locomotion_system.cpp
@@ -262,7 +262,7 @@ JointAngles HexapodLocomotionSystem::calculateInverseKinematics(int leg,
 
         Eigen::Matrix3f J = calculateAnalyticJacobian(leg, q);
 
-        //  Δq = Jᵀ (J Jᵀ + λ²I)⁻¹ e      (Levenberg-Marquardt)  :contentReference[oaicite:2]{index=2}
+        //  Δq = Jᵀ (J Jᵀ + λ²I)⁻¹ e      (Levenberg-Marquardt) 
         const float lambda = params.ik.use_damping ? params.ik.damping_lambda : 0.0f;
         Eigen::Matrix3f Z = (J * J.transpose() + lambda * lambda * Eigen::Matrix3f::Identity()).inverse();
         Eigen::Vector3f dq = J.transpose() * Z * e;


### PR DESCRIPTION
## Summary
- clean up comments in `hexapod_locomotion_system` by removing leftover `:contentReference[oaicite:...]` tags

## Testing
- `g++ -std=c++11 -c src/hexapod_locomotion_system.cpp -I include` *(fails: Arduino.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6843b5dec1208323849af39b33157bbb