### PR TITLE
Fix Eigen dependency for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,16 @@ Simple mock implementations of these interfaces are provided under the
 `examples/` directory.
 
 ## Running tests
-Basic tests for the utility functions can be built using `make` inside the
-`tests/` folder:
+The test suite depends on the Eigen library. A helper script in the
+`tests/` directory installs this dependency automatically on both Linux and
+macOS. Ensure you have **Homebrew** installed when running on macOS.
+After executing the script, build the tests using `make`:
 
 ```bash
 cd tests
-make && ./utils_test
+./setup.sh
+make
 ```
+
+Each test binary can be executed individually once the build completes.
 

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  if brew ls --versions eigen >/dev/null 2>&1; then
+    echo "Eigen library already installed via Homebrew"
+  else
+    echo "Installing Eigen library with Homebrew..."
+    brew update
+    brew install eigen
+  fi
+else
+  if dpkg -s libeigen3-dev >/dev/null 2>&1; then
+    echo "Eigen library already installed"
+  else
+    echo "Installing Eigen library via apt..."
+    sudo apt-get update
+    sudo apt-get install -y libeigen3-dev
+  fi
+fi


### PR DESCRIPTION
## Summary
- add `setup.sh` to automatically install libeigen3-dev for tests
- update README with new test instructions
- support macOS Eigen installation via Homebrew

## Testing
- `./tests/setup.sh`
- `make -C tests math_utils_test`


------
https://chatgpt.com/codex/tasks/task_e_6844a1dd6b1c8323ae5510742e3c795b