### PR TITLE
Fix Eigen include path detection for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Simple mock implementations of these interfaces are provided under the
 The test suite depends on the Eigen library. A helper script in the
 `tests/` directory installs this dependency automatically on both Linux and
 macOS. Ensure you have **Homebrew** installed when running on macOS.
+The accompanying `Makefile` will detect the Eigen installation path on
+macOS using `brew --prefix eigen`, so no manual configuration is required.
 After executing the script, build the tests using `make`:
 
 ```bash

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,11 @@
 CXX=g++
-CXXFLAGS=-I../include -I. -I/usr/include/eigen3 -std=c++17
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+EIGEN_PATH := $(shell brew --prefix eigen 2>/dev/null)/include/eigen3
+else
+EIGEN_PATH := /usr/include/eigen3
+endif
+CXXFLAGS=-I../include -I. -I$(EIGEN_PATH) -std=c++17
 
 all: math_utils_test model_test pose_controller_test walk_controller_test admittance_controller_test locomotion_system_test
 


### PR DESCRIPTION
## Summary
- update tests `Makefile` to locate Eigen using `brew --prefix` on macOS
- document automatic Eigen path detection in `README`

## Testing
- `./tests/setup.sh`
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_e_6844a57585508323ad99a5d693d43c01