### PR TITLE
Add tripod gait simulation test

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,7 +7,7 @@ EIGEN_PATH := /usr/include/eigen3
 endif
 CXXFLAGS=-I../include -I. -I$(EIGEN_PATH) -std=c++17
 
-all: math_utils_test model_test pose_controller_test walk_controller_test admittance_controller_test locomotion_system_test
+all: math_utils_test model_test pose_controller_test walk_controller_test admittance_controller_test locomotion_system_test tripod_gait_sim_test
 
 math_utils_test: math_utils_test.cpp ../src/math_utils.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
@@ -27,5 +27,8 @@ admittance_controller_test: admittance_controller_test.cpp ../src/admittance_con
 locomotion_system_test: locomotion_system_test.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/admittance_controller.cpp ../src/math_utils.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
+tripod_gait_sim_test: tripod_gait_sim_test.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/admittance_controller.cpp ../src/math_utils.cpp
+	$(CXX) $(CXXFLAGS) $^ -o $@
+
 clean:
-	rm -f math_utils_test model_test pose_controller_test walk_controller_test admittance_controller_test locomotion_system_test
+	rm -f math_utils_test model_test pose_controller_test walk_controller_test admittance_controller_test locomotion_system_test tripod_gait_sim_test


### PR DESCRIPTION
## Summary
- add simulation test for tripod gait
- compile test via Makefile

## Testing
- `./setup.sh`
- `make`
- `./math_utils_test`
- `./model_test`
- `./pose_controller_test`
- `./walk_controller_test`
- `./admittance_controller_test`
- `./locomotion_system_test`
- `./tripod_gait_sim_test > /tmp/test_tripod.log && tail -n 5 /tmp/test_tripod.log`


------
https://chatgpt.com/codex/tasks/task_e_6845b0a845748323973b48cf4761c19a