### PR TITLE
Document hexagonal body shape

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,12 @@
 # AGENT Instructions
 
 Este archivo define las pautas para colaborar en HexaMotion.
+## Objetivo
+Esta librería proporciona control de locomoción para un robot hexápodo basado en Arduino Giga R1.
+El cuerpo del robot es un hexágono con las patas separadas 60° entre sí.
+Incluye cinemática inversa con parámetros DH y jacobianos, control de orientación y pose, planificador de marchas y manejo de errores.
+Las interfaces `IIMUInterface`, `IFSRInterface` e `IServoInterface` deben implementarse para conectar el IMU, los sensores FSR y los servos inteligentes.
+
 
 ## Estilo de código
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@ Library for controlling locomotion, gait, and pose of a hexapod robot.
 
 ## Overview
 HexaMotion provides kinematic and gait planning utilities to drive a six legged robot.  It is designed for use with the **Arduino Giga R1** and relies on the [ArduinoEigen](https://github.com/arduino-libraries/ArduinoEigen) package for matrix math.
+The robot body forms a hexagon, so each coxa joint is mounted at a 60° interval around the center.
+## Features
+- Inverse kinematics using DH parameters and Jacobians.
+- Pose and orientation control via IMU feedback.
+- Multiple gait planner with tripod, wave, ripple and metachronal options.
+- FSR input for contact detection.
+- Smart servo interface for precise joint control.
+- Error reporting and self tests.
+
 
 ## Prerequisites
 - Arduino IDE with board support for **Arduino Giga R1**.
@@ -58,6 +67,15 @@ Simple mock implementations of these interfaces are provided under the
 Debug logging can be enabled by defining the `ENABLE_LOG` macro before
 including the library. When active, certain events such as joint limit
 violations will be printed to the serial console.
+## Configurable parameters
+The `Parameters` structure defines the physical dimensions and control limits of the robot. Key fields include:
+- `hexagon_radius`, `coxa_length`, `femur_length`, `tibia_length`.
+- `robot_height` and `robot_weight`.
+- Joint angle limits for coxa, femur and tibia.
+- IMU and FSR calibration settings.
+- Gait tuning factors and control frequency.
+See `include/locomotion_system.h` for a detailed list.
+
 
 ## Running tests
 The test suite depends on the Eigen library. A helper script in the


### PR DESCRIPTION
## Summary
- note that each coxa sits at a vertex of the body hexagon in README
- document hexagonal body in AGENTS instructions

## Testing
- `./setup.sh`
- `make`
- `./math_utils_test`
- `./model_test`
- `./pose_controller_test`
- `./walk_controller_test`
- `./admittance_controller_test`
- `./locomotion_system_test`
- `./ik_debug_test`
- `./height_range_test`
- `./tripod_gait_sim_test` *(fails: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68460b500a948323bb183f69c65ab85c