### PR TITLE
Add Bezier curve utilities

### DIFF
--- a/include/math_utils.h
+++ b/include/math_utils.h
@@ -22,6 +22,48 @@ Eigen::Vector4f eulerToQuaternion(const Eigen::Vector3f &euler);
 Eigen::Vector4f quaternionMultiply(const Eigen::Vector4f &q1, const Eigen::Vector4f &q2);
 Eigen::Vector4f quaternionInverse(const Eigen::Vector4f &q);
 Eigen::Matrix4f dhTransform(float a, float alpha, float d, float theta);
+
+template <class T>
+inline T quadraticBezier(const T *points, double t) {
+    double s = 1.0 - t;
+    return points[0] * (s * s) + points[1] * (2.0 * t * s) + points[2] * (t * t);
+}
+
+template <class T>
+inline T cubicBezier(const T *points, double t) {
+    double s = 1.0 - t;
+    return points[0] * (s * s * s) +
+           points[1] * (3.0 * t * s * s) +
+           points[2] * (3.0 * t * t * s) +
+           points[3] * (t * t * t);
+}
+
+template <class T>
+inline T cubicBezierDot(const T *points, double t) {
+    double s = 1.0 - t;
+    return 3.0 * s * s * (points[1] - points[0]) +
+           6.0 * s * t * (points[2] - points[1]) +
+           3.0 * t * t * (points[3] - points[2]);
+}
+
+template <class T>
+inline T quarticBezier(const T *points, double t) {
+    double s = 1.0 - t;
+    return points[0] * (s * s * s * s) +
+           points[1] * (4.0 * t * s * s * s) +
+           points[2] * (6.0 * t * t * s * s) +
+           points[3] * (4.0 * t * t * t * s) +
+           points[4] * (t * t * t * t);
+}
+
+template <class T>
+inline T quarticBezierDot(const T *points, double t) {
+    double s = 1.0 - t;
+    return 4.0 * s * s * s * (points[1] - points[0]) +
+           12.0 * s * s * t * (points[2] - points[1]) +
+           12.0 * s * t * t * (points[3] - points[2]) +
+           4.0 * t * t * t * (points[4] - points[3]);
+}
 } // namespace math_utils
 
 #endif // MATH_UTILS_H

--- a/src/walk_controller.cpp
+++ b/src/walk_controller.cpp
@@ -56,9 +56,20 @@ Point3D WalkController::footTrajectory(int leg_index, float phase, float step_he
     } else {
         leg_states[leg_index] = SWING_PHASE;
         float swing_progress = (leg_phase - stance_duration) / swing_duration;
-        trajectory.x = default_foot_x + step_length * (swing_progress - 0.5f);
-        trajectory.y = default_foot_y;
-        trajectory.z = -robot_height + step_height * sin(M_PI * swing_progress);
+
+        Eigen::Vector3f ctrl[5];
+        float start_x = default_foot_x - step_length * 0.5f;
+        float end_x = default_foot_x + step_length * 0.5f;
+        float z_base = -robot_height;
+        ctrl[0] = Eigen::Vector3f(start_x, default_foot_y, z_base);
+        ctrl[1] = Eigen::Vector3f(start_x, default_foot_y, z_base + step_height * 0.5f);
+        ctrl[2] = Eigen::Vector3f((start_x + end_x) / 2.0f, default_foot_y, z_base + step_height);
+        ctrl[3] = Eigen::Vector3f(end_x, default_foot_y, z_base + step_height * 0.5f);
+        ctrl[4] = Eigen::Vector3f(end_x, default_foot_y, z_base);
+        Eigen::Vector3f pos = math_utils::quarticBezier(ctrl, swing_progress);
+        trajectory.x = pos[0];
+        trajectory.y = pos[1];
+        trajectory.z = pos[2];
     }
     return trajectory;
 }


### PR DESCRIPTION
## Summary
- include Bezier curve functions in `math_utils`
- generate swing trajectories via quartic Bezier curves

## Testing
- `cd tests && ./setup.sh`
- `make math_utils_test walk_controller_test`
- `./math_utils_test && ./walk_controller_test`

------
https://chatgpt.com/codex/tasks/task_e_6847852ee2cc8323b20d92bee2ba0cf0