### PR TITLE
Run all tests and align parameters

### DIFF
--- a/tests/final_validation_test.cpp
+++ b/tests/final_validation_test.cpp
@@ -5,13 +5,7 @@
 int main() {
     std::cout << "=== FINAL VALIDATION: METACHRONAL & ADAPTIVE GAIT FUNCTIONALITY ===" << std::endl;
 
-    Parameters p{};
-    p.hexagon_radius = 400;
-    p.coxa_length = 50;
-    p.femur_length = 101;
-    p.tibia_length = 208;
-    p.robot_height = 150;
-    p.control_frequency = 50;
+    Parameters p = createDefaultParameters();
 
     LocomotionSystem sys(p);
     DummyIMU imu;

--- a/tests/pose_control_comprehensive_test.cpp
+++ b/tests/pose_control_comprehensive_test.cpp
@@ -4,10 +4,7 @@
 #include <cassert>
 #include <cmath>
 #include <iostream>
-
-#include <cassert>
-#include <cmath>
-#include <iostream>
+#include <memory>
 
 class PoseControlTest {
   private:
@@ -20,16 +17,7 @@ class PoseControlTest {
   public:
     PoseControlTest() {
         // Create test parameters
-        Parameters params;
-        params.hexagon_radius = 100.0f;
-        params.coxa_length = 50.0f;
-        params.femur_length = 100.0f;
-        params.tibia_length = 120.0f;
-        params.robot_height = 120.0f;
-        params.max_velocity = 200.0f;
-        params.max_angular_velocity = 90.0f;
-        params.stability_margin = 30.0f;
-        params.control_frequency = 50.0f;
+        Parameters params = createDefaultParameters();
 
         // Create locomotion system
         locomotion_system_ = std::make_unique<LocomotionSystem>(params);

--- a/tests/quaternion_pose_system_test.cpp
+++ b/tests/quaternion_pose_system_test.cpp
@@ -9,18 +9,7 @@ int main() {
     std::cout << "=== Test Quaternion-based Pose System ===" << std::endl;
 
     // Initialize test environment
-    Parameters params{};
-    params.hexagon_radius = 200;
-    params.coxa_length = 50;
-    params.femur_length = 100;
-    params.tibia_length = 150;
-    params.robot_height = 100;
-    params.coxa_angle_limits[0] = -90;
-    params.coxa_angle_limits[1] = 90;
-    params.femur_angle_limits[0] = -90;
-    params.femur_angle_limits[1] = 90;
-    params.tibia_angle_limits[0] = -90;
-    params.tibia_angle_limits[1] = 90;
+    Parameters params = createDefaultParameters();
 
     RobotModel model(params);
     DummyServo servos;

--- a/tests/state_controller_test.cpp
+++ b/tests/state_controller_test.cpp
@@ -41,21 +41,7 @@ class StateControllerTest {
     }
 
     void setupParameters() {
-        params.hexagon_radius = 150;
-        params.coxa_length = 50;
-        params.femur_length = 100;
-        params.tibia_length = 120;
-        params.robot_height = 80;
-        params.robot_weight = 2.5f;
-        params.control_frequency = 50;
-
-        // Set joint limits (required)
-        params.coxa_angle_limits[0] = -90;
-        params.coxa_angle_limits[1] = 90;
-        params.femur_angle_limits[0] = -90;
-        params.femur_angle_limits[1] = 90;
-        params.tibia_angle_limits[0] = -90;
-        params.tibia_angle_limits[1] = 90;
+        params = createDefaultParameters();
     }
 
     void assert_test(bool condition, const std::string &test_name) {

--- a/tests/test_metachronal_adaptive_gaits.cpp
+++ b/tests/test_metachronal_adaptive_gaits.cpp
@@ -8,13 +8,7 @@
 int main() {
     std::cout << "Testing METACHRONAL_GAIT and ADAPTIVE_GAIT implementation status..." << std::endl;
 
-    Parameters p{};
-    p.hexagon_radius = 400;
-    p.coxa_length = 50;
-    p.femur_length = 101;
-    p.tibia_length = 208;
-    p.robot_height = 150;
-    p.control_frequency = 50;
+    Parameters p = createDefaultParameters();
 
     LocomotionSystem sys(p);
     DummyIMU imu;


### PR DESCRIPTION
## Summary
- ensure selected tests use default parameters from `createDefaultParameters`
- run all test executables after compilation

## Testing
- `tests/setup.sh`
- `make pose_control_comprehensive_test test_metachronal_adaptive_gaits quaternion_pose_system_test final_validation_test state_controller_test`
- `./pose_control_comprehensive_test`
- `./test_metachronal_adaptive_gaits`
- `./quaternion_pose_system_test`
- `./final_validation_test`
- `./state_controller_test`


------
https://chatgpt.com/codex/tasks/task_e_684f97e481e083238a0e40e59d5382c4