### PR TITLE
Fix tests to compile with explicit constructors

### DIFF
--- a/tests/actual_workspace_test.cpp
+++ b/tests/actual_workspace_test.cpp
@@ -98,10 +98,11 @@ int main() {
     };
 
     TestCase test_cases[] = {
-        {{0.0f, -45.0f, 90.0f}, "Test 1 (working)"},
-        {{-45.0f, 45.0f, -90.0f}, "Test 3 (failing)"},
-        {{90.0f, 0.0f, 0.0f}, "Test 5 (failing)"},
-        {{0.0f, 0.0f, 0.0f}, "Test 6 (failing)"}};
+        {JointAngles{0.0f, -45.0f, 90.0f}, "Test 1 (working)"},
+        {JointAngles{-45.0f, 45.0f, -90.0f}, "Test 3 (failing)"},
+        {JointAngles{90.0f, 0.0f, 0.0f}, "Test 5 (failing)"},
+        {JointAngles{0.0f, 0.0f, 0.0f}, "Test 6 (failing)"}
+    };
 
     for (const TestCase &test : test_cases) {
         Point3D target = model.forwardKinematics(0, test.config);

--- a/tests/angle_normalization_test.cpp
+++ b/tests/angle_normalization_test.cpp
@@ -50,12 +50,12 @@ int main() {
     // Test IK with targets that are definitely reachable
     std::cout << "\n=== IK Reachable Targets Test ===" << std::endl;
     std::vector<Point3D> reachable_targets = {
-        {550, 100, 0},    // Target in first quadrant
-        {500, 150, -30},  // Target in first quadrant with Z
-        {450, -100, 20},  // Target in fourth quadrant
-        {500, -150, -40}, // Target in fourth quadrant with Z
-        {600, 50, -60},   // Forward-right
-        {600, -50, -60}   // Forward-left
+        Point3D{550, 100, 0},    // Target in first quadrant
+        Point3D{500, 150, -30},  // Target in first quadrant with Z
+        Point3D{450, -100, 20},  // Target in fourth quadrant
+        Point3D{500, -150, -40}, // Target in fourth quadrant with Z
+        Point3D{600, 50, -60},   // Forward-right
+        Point3D{600, -50, -60}   // Forward-left
     };
 
     int valid_solutions = 0;

--- a/tests/angle_range_test.cpp
+++ b/tests/angle_range_test.cpp
@@ -27,14 +27,14 @@ int main() {
 
     // Test various targets and check if angles exceed limits
     std::vector<Point3D> test_targets = {
-        {759, 0, 0},      // Horizontal straight
-        {600, 300, -50},  // Forward-right, down
-        {400, 400, -100}, // Diagonal, down
-        {200, 500, 50},   // Near, right, up
-        {700, -200, -30}, // Forward-left, down
-        {300, -400, 80},  // Near-left, up
-        {500, 0, -150},   // Forward, far down
-        {450, 350, 100}   // Forward-right, up
+        Point3D{759, 0, 0},      // Horizontal straight
+        Point3D{600, 300, -50},  // Forward-right, down
+        Point3D{400, 400, -100}, // Diagonal, down
+        Point3D{200, 500, 50},   // Near, right, up
+        Point3D{700, -200, -30}, // Forward-left, down
+        Point3D{300, -400, 80},  // Near-left, up
+        Point3D{500, 0, -150},   // Forward, far down
+        Point3D{450, 350, 100}   // Forward-right, up
     };
 
     int violations = 0;

--- a/tests/dls_validation_test.cpp
+++ b/tests/dls_validation_test.cpp
@@ -34,13 +34,13 @@ int main() {
 
     // Test configurations
     JointAngles test_configs[] = {
-        {0.0f, -45.0f, 90.0f},   // Original failing case
-        {30.0f, -30.0f, 60.0f},  // Moderate angles
-        {-45.0f, 45.0f, -90.0f}, // Negative angles
-        {0.0f, -60.0f, 120.0f},  // More extreme bending
-        {90.0f, 0.0f, 0.0f},     // Pure rotation
-        {0.0f, 0.0f, 0.0f},      // Straight leg
-        {-30.0f, -75.0f, 135.0f} // Near limits
+        JointAngles{0.0f, -45.0f, 90.0f},   // Original failing case
+        JointAngles{30.0f, -30.0f, 60.0f},  // Moderate angles
+        JointAngles{-45.0f, 45.0f, -90.0f}, // Negative angles
+        JointAngles{0.0f, -60.0f, 120.0f},  // More extreme bending
+        JointAngles{90.0f, 0.0f, 0.0f},     // Pure rotation
+        JointAngles{0.0f, 0.0f, 0.0f},      // Straight leg
+        JointAngles{-30.0f, -75.0f, 135.0f} // Near limits
     };
 
     int num_tests = sizeof(test_configs) / sizeof(test_configs[0]);

--- a/tests/edge_case_analysis.cpp
+++ b/tests/edge_case_analysis.cpp
@@ -69,10 +69,10 @@ int main() {
     // Test some valid reachable targets
     std::cout << "\n=== Valid Reachable Targets ===" << std::endl;
     std::vector<Point3D> valid_targets = {
-        {759, 0, 0},     // Straight
-        {600, 0, -50},   // Forward down
-        {500, 200, 0},   // Forward right
-        {450, -150, 100} // Forward left up
+        Point3D{759, 0, 0},     // Straight
+        Point3D{600, 0, -50},   // Forward down
+        Point3D{500, 200, 0},   // Forward right
+        Point3D{450, -150, 100} // Forward left up
     };
 
     for (size_t i = 0; i < valid_targets.size(); ++i) {

--- a/tests/ik_debug_analysis.cpp
+++ b/tests/ik_debug_analysis.cpp
@@ -33,8 +33,8 @@ int main() {
 
     // Test the failing cases
     JointAngles failing_configs[] = {
-        {-45.0f, 45.0f, -90.0f}, // Test 3
-        {90.0f, 0.0f, 0.0f}      // Test 5
+        JointAngles{-45.0f, 45.0f, -90.0f}, // Test 3
+        JointAngles{90.0f, 0.0f, 0.0f}      // Test 5
     };
 
     for (int i = 0; i < 2; i++) {
@@ -80,9 +80,9 @@ int main() {
 
     // Test some positions that should work well
     Point3D test_positions[] = {
-        {600.0f, 100.0f, -100.0f}, // Moderate reach
-        {500.0f, 200.0f, 0.0f},    // Different angle
-        {450.0f, 0.0f, -50.0f}     // Straight ahead
+        Point3D{600.0f, 100.0f, -100.0f}, // Moderate reach
+        Point3D{500.0f, 200.0f, 0.0f},    // Different angle
+        Point3D{450.0f, 0.0f, -50.0f}     // Straight ahead
     };
 
     for (int i = 0; i < 3; i++) {

--- a/tests/terrain_adaptation_test.cpp
+++ b/tests/terrain_adaptation_test.cpp
@@ -71,6 +71,12 @@ class TerrainIMUMock : public IIMUInterface {
     bool initialize() override { return true; }
     bool calibrate() override { return true; }
     bool isConnected() override { return true; }
+    bool setIMUMode(IMUMode) override { return true; }
+    IMUMode getIMUMode() const override { return IMU_MODE_RAW_DATA; }
+    bool hasAbsolutePositioning() const override { return true; }
+    bool getCalibrationStatus(uint8_t *, uint8_t *, uint8_t *, uint8_t *) override { return true; }
+    bool runSelfTest() override { return true; }
+    bool resetOrientation() override { return true; }
 
     IMUData readIMU() override {
         return imu_data_;

--- a/tests/workspace_analysis.cpp
+++ b/tests/workspace_analysis.cpp
@@ -47,10 +47,10 @@ int main() {
 
     // Test the targets from the failing cases
     JointAngles test_configs[] = {
-        {0.0f, -45.0f, 90.0f},   // Test 1 (working)
-        {-45.0f, 45.0f, -90.0f}, // Test 3 (failing)
-        {90.0f, 0.0f, 0.0f},     // Test 5 (failing)
-        {0.0f, 0.0f, 0.0f}       // Test 6 (failing)
+        JointAngles{0.0f, -45.0f, 90.0f},   // Test 1 (working)
+        JointAngles{-45.0f, 45.0f, -90.0f}, // Test 3 (failing)
+        JointAngles{90.0f, 0.0f, 0.0f},     // Test 5 (failing)
+        JointAngles{0.0f, 0.0f, 0.0f}       // Test 6 (failing)
     };
 
     const char *test_names[] = {


### PR DESCRIPTION
## Summary
- adjust initializer lists in test cases to respect explicit constructors
- implement missing virtual methods in TerrainIMUMock
- update workspace and edge case analyses

## Testing
- `./setup.sh`
- `make`
- `./actual_workspace_test`
- `./dls_validation_test`
- `./terrain_adaptation_test`
- `./pose_control_equivalence_test`


------
https://chatgpt.com/codex/tasks/task_e_68509a4f47ec832393d82017ca89903c