### PR TITLE
Fix tests include paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The `Parameters` structure defines the physical dimensions and control limits of
 -   Joint angle limits for coxa, femur and tibia.
 -   IMU and FSR calibration settings.
 -   Gait tuning factors and control frequency.
-    See `include/locomotion_system.h` for a detailed list.
+    See `src/locomotion_system.h` for a detailed list.
 
 ## Running tests
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,7 +5,7 @@ EIGEN_PATH := $(shell brew --prefix eigen 2>/dev/null)/include/eigen3
 else
 EIGEN_PATH := /usr/include/eigen3
 endif
-CXXFLAGS=-I../include -I. -I$(EIGEN_PATH) -std=c++17
+CXXFLAGS=-I../src -I. -I$(EIGEN_PATH) -std=c++17
 
 SOURCES = ../src/math_utils.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/manual_pose_controller.cpp ../src/state_controller.cpp ../src/locomotion_system.cpp
 

--- a/tests/absolute_positioning_compile_test.cpp
+++ b/tests/absolute_positioning_compile_test.cpp
@@ -1,9 +1,9 @@
-#include "../include/HexaModel.h"
-#include "../include/imu_auto_pose.h"
+#include "../src/HexaModel.h"
+#include "../src/imu_auto_pose.h"
 #include "../tests/test_stubs.h"
 
-#include "../include/HexaModel.h"
-#include "../include/imu_auto_pose.h"
+#include "../src/HexaModel.h"
+#include "../src/imu_auto_pose.h"
 #include "../tests/test_stubs.h"
 #include <iomanip>
 #include <iostream>

--- a/tests/admittance_controller_test.cpp
+++ b/tests/admittance_controller_test.cpp
@@ -1,4 +1,4 @@
-#include "../include/admittance_controller.h"
+#include "../src/admittance_controller.h"
 #include "test_stubs.h"
 #include <cassert>
 #include <iostream>

--- a/tests/angle_test.cpp
+++ b/tests/angle_test.cpp
@@ -1,5 +1,5 @@
 // Test to understand angle conventions
-#include "../include/locomotion_system.h"
+#include "../src/locomotion_system.h"
 #include "test_stubs.h"
 #include <cmath>
 #include <iostream>

--- a/tests/coord_test.cpp
+++ b/tests/coord_test.cpp
@@ -1,5 +1,5 @@
 // Test to understand the coordinate system and fix IK
-#include "../include/locomotion_system.h"
+#include "../src/locomotion_system.h"
 #include "test_stubs.h"
 #include <cmath>
 #include <iostream>

--- a/tests/cruise_control_comprehensive_test.cpp
+++ b/tests/cruise_control_comprehensive_test.cpp
@@ -10,8 +10,8 @@
  * @date 2025
  */
 
-#include "../include/locomotion_system.h"
-#include "../include/state_controller.h"
+#include "../src/locomotion_system.h"
+#include "../src/state_controller.h"
 #include "test_stubs.h"
 #include <cassert>
 #include <chrono>

--- a/tests/enhanced_imu_integration_test.cpp
+++ b/tests/enhanced_imu_integration_test.cpp
@@ -1,5 +1,5 @@
-#include "../include/locomotion_system.h"
-#include "../include/terrain_adaptation.h"
+#include "../src/locomotion_system.h"
+#include "../src/terrain_adaptation.h"
 #include "test_stubs.h"
 #include <iostream>
 

--- a/tests/full_feature_sim_test.cpp
+++ b/tests/full_feature_sim_test.cpp
@@ -1,9 +1,9 @@
-#include "../include/admittance_controller.h"
-#include "../include/imu_auto_pose.h"
-#include "../include/locomotion_system.h"
-#include "../include/manual_pose_controller.h"
-#include "../include/precision_config.h"
-#include "../include/state_controller.h"
+#include "../src/admittance_controller.h"
+#include "../src/imu_auto_pose.h"
+#include "../src/locomotion_system.h"
+#include "../src/manual_pose_controller.h"
+#include "../src/precision_config.h"
+#include "../src/state_controller.h"
 #include "test_stubs.h"
 #include <cassert>
 #include <chrono>

--- a/tests/geometry_test.cpp
+++ b/tests/geometry_test.cpp
@@ -1,5 +1,5 @@
 // Test to validate the geometry and coordinate systems
-#include "../include/locomotion_system.h"
+#include "../src/locomotion_system.h"
 #include "test_stubs.h"
 #include <cmath>
 #include <iostream>

--- a/tests/height_range_test.cpp
+++ b/tests/height_range_test.cpp
@@ -1,4 +1,4 @@
-#include "../include/HexaModel.h"
+#include "../src/HexaModel.h"
 #include <cassert>
 #include <iostream>
 

--- a/tests/ik_analytical_fix.cpp
+++ b/tests/ik_analytical_fix.cpp
@@ -1,4 +1,4 @@
-#include "../include/locomotion_system.h"
+#include "../src/locomotion_system.h"
 #include "test_stubs.h"
 #include <cmath>
 #include <iostream>

--- a/tests/ik_coordinate_test.cpp
+++ b/tests/ik_coordinate_test.cpp
@@ -1,5 +1,5 @@
 // Test to understand the coordinate system and fix IK
-#include "../include/locomotion_system.h"
+#include "../src/locomotion_system.h"
 #include "test_stubs.h"
 #include <cmath>
 #include <iostream>

--- a/tests/ik_debug_test.cpp
+++ b/tests/ik_debug_test.cpp
@@ -1,4 +1,4 @@
-#include "../include/locomotion_system.h"
+#include "../src/locomotion_system.h"
 #include "test_stubs.h"
 #include <cmath>
 #include <iostream>

--- a/tests/ik_multiple_starts_test.cpp
+++ b/tests/ik_multiple_starts_test.cpp
@@ -1,4 +1,4 @@
-#include "../include/locomotion_system.h"
+#include "../src/locomotion_system.h"
 #include "test_stubs.h"
 #include <chrono>
 #include <iomanip>

--- a/tests/locomotion_system_test.cpp
+++ b/tests/locomotion_system_test.cpp
@@ -1,4 +1,4 @@
-#include "../include/locomotion_system.h"
+#include "../src/locomotion_system.h"
 #include "test_stubs.h"
 #include <cassert>
 #include <iostream>

--- a/tests/math_utils_test.cpp
+++ b/tests/math_utils_test.cpp
@@ -1,6 +1,6 @@
 #include <cassert>
 #include <iostream>
-#include "../include/math_utils.h"
+#include "../src/math_utils.h"
 
 int main() {
     using namespace math_utils;

--- a/tests/model_test.cpp
+++ b/tests/model_test.cpp
@@ -1,4 +1,4 @@
-#include "../include/HexaModel.h"
+#include "../src/HexaModel.h"
 #include <cassert>
 #include <iostream>
 

--- a/tests/openshc_equivalent_features_test.cpp
+++ b/tests/openshc_equivalent_features_test.cpp
@@ -1,8 +1,8 @@
-#include "../include/admittance_controller.h"
-#include "../include/imu_auto_pose.h"
-#include "../include/manual_pose_controller.h"
-#include "../include/walk_controller.h"
-#include "../include/walkspace_analyzer.h"
+#include "../src/admittance_controller.h"
+#include "../src/imu_auto_pose.h"
+#include "../src/manual_pose_controller.h"
+#include "../src/walk_controller.h"
+#include "../src/walkspace_analyzer.h"
 #include "test_stubs.h"
 #include <cassert>
 #include <iostream>

--- a/tests/pose_controller_test.cpp
+++ b/tests/pose_controller_test.cpp
@@ -1,4 +1,4 @@
-#include "../include/pose_controller.h"
+#include "../src/pose_controller.h"
 #include "test_stubs.h"
 #include <cassert>
 #include <iostream>

--- a/tests/runge_kutta_validation_test.cpp
+++ b/tests/runge_kutta_validation_test.cpp
@@ -1,4 +1,4 @@
-#include "../include/admittance_controller.h"
+#include "../src/admittance_controller.h"
 #include "test_stubs.h"
 #include <cassert>
 #include <cmath>

--- a/tests/state_controller_runtime_test.cpp
+++ b/tests/state_controller_runtime_test.cpp
@@ -3,8 +3,8 @@
  * @brief Runtime validation test for StateController
  */
 
-#include "../include/locomotion_system.h"
-#include "../include/state_controller.h"
+#include "../src/locomotion_system.h"
+#include "../src/state_controller.h"
 #include "test_stubs.h"
 #include <iomanip>
 #include <iostream>

--- a/tests/state_controller_test.cpp
+++ b/tests/state_controller_test.cpp
@@ -5,8 +5,8 @@
  * @date 2024
  */
 
-#include "../include/locomotion_system.h"
-#include "../include/state_controller.h"
+#include "../src/locomotion_system.h"
+#include "../src/state_controller.h"
 #include "test_stubs.h"
 #include <cassert>
 #include <chrono>

--- a/tests/terrain_adaptation_test.cpp
+++ b/tests/terrain_adaptation_test.cpp
@@ -1,5 +1,5 @@
-#include "../include/terrain_adaptation.h"
-#include "../include/walk_controller.h"
+#include "../src/terrain_adaptation.h"
+#include "../src/walk_controller.h"
 #include "test_stubs.h"
 #include <cassert>
 #include <cmath>

--- a/tests/test_isPointReachable.cpp
+++ b/tests/test_isPointReachable.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
-#include "../include/math_utils.h"
-#include "../include/HexaModel.h"
+#include "../src/math_utils.h"
+#include "../src/HexaModel.h"
 
 int main() {
     std::cout << "=== Test isPointReachable Function ===" << std::endl;

--- a/tests/test_stubs.h
+++ b/tests/test_stubs.h
@@ -1,7 +1,7 @@
 #ifndef TEST_STUBS_H
 #define TEST_STUBS_H
 
-#include "../include/HexaModel.h"
+#include "../src/HexaModel.h"
 #include <cmath>
 #include <iostream>
 #include <random>

--- a/tests/tripod_gait_ik_config_test.cpp
+++ b/tests/tripod_gait_ik_config_test.cpp
@@ -1,4 +1,4 @@
-#include "../include/locomotion_system.h"
+#include "../src/locomotion_system.h"
 #include "test_stubs.h"
 #include <iomanip>
 #include <iostream>

--- a/tests/tripod_gait_sim_test.cpp
+++ b/tests/tripod_gait_sim_test.cpp
@@ -1,5 +1,5 @@
-#include "../include/locomotion_system.h"
-#include "../include/state_controller.h"
+#include "../src/locomotion_system.h"
+#include "../src/state_controller.h"
 #include "test_stubs.h"
 #include <cassert>
 #include <chrono>

--- a/tests/walk_controller_test.cpp
+++ b/tests/walk_controller_test.cpp
@@ -1,4 +1,4 @@
-#include "../include/walk_controller.h"
+#include "../src/walk_controller.h"
 #include "test_stubs.h"
 #include <cassert>
 #include <iostream>


### PR DESCRIPTION
## Summary
- fix README path to locomotion_system.h
- update all tests to include headers from src
- adjust tests/Makefile include path

## Testing
- `./setup.sh`
- `make`
- `./math_utils_test`
- `./locomotion_system_test`
- `./final_validation_test`

------
https://chatgpt.com/codex/tasks/task_e_68525e1225fc8323bbfaa91b4c0109e7