### PR TITLE
Fix tripod gait default foot positions

### DIFF
--- a/src/robot_model.cpp
+++ b/src/robot_model.cpp
@@ -74,107 +74,34 @@ JointAngles RobotModel::inverseKinematics(int leg, const Point3D &p_target) cons
         return JointAngles(coxa_angle, -45.0f, 60.0f);
     }
 
-    // Initial guess based on target direction and realistic kinematics
-    float coxa_start = atan2(local_target.y, local_target.x) * RADIANS_TO_DEGREES_FACTOR;
-    coxa_start = constrainAngle(coxa_start, params.coxa_angle_limits[0], params.coxa_angle_limits[1]);
+    // Geometric inverse kinematics solution
+    float coxa_angle = atan2(local_target.y, local_target.x);
+    float planar_dist = sqrt(local_target.x * local_target.x + local_target.y * local_target.y) - params.coxa_length;
+    float leg_dist = sqrt(planar_dist * planar_dist + local_target.z * local_target.z);
 
-    // Better initial guess for femur and tibia based on target position
-    float target_distance_xy = sqrt(local_target.x * local_target.x + local_target.y * local_target.y);
-    float target_height = -local_target.z; // Convert to positive height
-
-    // Initial estimates for femur and tibia
-    float femur_estimate = 0.0f;
-    float tibia_estimate = 0.0f;
-
-    // Optional: geometric approximation fallback
-    if (femur_estimate == 0.0f && tibia_estimate == 0.0f && target_distance_xy > params.coxa_length && target_height > 0) {
-        float remaining_xy = target_distance_xy - params.coxa_length;
-        float leg_reach = sqrt(remaining_xy * remaining_xy + target_height * target_height);
-        if (leg_reach <= (params.femur_length + params.tibia_length) * 0.95f) {
-            float c = leg_reach;
-            float a = params.femur_length;
-            float b = params.tibia_length;
-            float cos_alpha = (a * a + c * c - b * b) / (2 * a * c);
-            if (cos_alpha >= -1.0f && cos_alpha <= 1.0f) {
-                float alpha = acos(cos_alpha);
-                float theta = atan2(target_height, remaining_xy);
-                femur_estimate = (theta - alpha) * RADIANS_TO_DEGREES_FACTOR;
-                float cos_beta = (a * a + b * b - c * c) / (2 * a * b);
-                if (cos_beta >= -1.0f && cos_beta <= 1.0f) {
-                    float beta = acos(cos_beta);
-                    tibia_estimate = (M_PI - beta) * RADIANS_TO_DEGREES_FACTOR;
-                }
-            }
-        }
+    if (leg_dist > max_reach || leg_dist < min_reach) {
+        coxa_angle = constrainAngle(coxa_angle * RADIANS_TO_DEGREES_FACTOR, params.coxa_angle_limits[0], params.coxa_angle_limits[1]);
+        return JointAngles(coxa_angle, -45.0f, 60.0f);
     }
 
-    // Clamp initial estimates to joint limits
-    femur_estimate = constrainAngle(femur_estimate, params.femur_angle_limits[0], params.femur_angle_limits[1]);
-    tibia_estimate = constrainAngle(tibia_estimate, params.tibia_angle_limits[0], params.tibia_angle_limits[1]);
+    float alpha = acos((params.femur_length * params.femur_length + leg_dist * leg_dist - params.tibia_length * params.tibia_length) /
+                       (2.0f * params.femur_length * leg_dist));
+    float beta = acos((params.femur_length * params.femur_length + params.tibia_length * params.tibia_length - leg_dist * leg_dist) /
+                      (2.0f * params.femur_length * params.tibia_length));
+    float theta = atan2(-local_target.z, planar_dist);
 
-    JointAngles current_angles(coxa_start, femur_estimate, tibia_estimate);
+    float femur_angle = theta + alpha;
+    float tibia_angle = M_PI - beta;
 
-    // Clamp to joint limits
-    current_angles.coxa = constrainAngle(current_angles.coxa, params.coxa_angle_limits[0], params.coxa_angle_limits[1]);
-    current_angles.femur = constrainAngle(current_angles.femur, params.femur_angle_limits[0], params.femur_angle_limits[1]);
-    current_angles.tibia = constrainAngle(current_angles.tibia, params.tibia_angle_limits[0], params.tibia_angle_limits[1]);
+    JointAngles result(coxa_angle * RADIANS_TO_DEGREES_FACTOR,
+                       femur_angle * RADIANS_TO_DEGREES_FACTOR,
+                       tibia_angle * RADIANS_TO_DEGREES_FACTOR);
 
-    // DLS iterative solution - production-ready 3x3 solver
-    const int max_iterations = params.ik.max_iterations;
-    const float tolerance = 0.001f;
-    const float dls_coefficient = 0.05f;
+    result.coxa = constrainAngle(result.coxa, params.coxa_angle_limits[0], params.coxa_angle_limits[1]);
+    result.femur = constrainAngle(result.femur, params.femur_angle_limits[0], params.femur_angle_limits[1]);
+    result.tibia = constrainAngle(result.tibia, params.tibia_angle_limits[0], params.tibia_angle_limits[1]);
 
-    for (int iter = 0; iter < max_iterations; ++iter) {
-        // Calculate current position using forward kinematics
-        Point3D current_pos = forwardKinematics(leg, current_angles);
-
-        // Position error (3D)
-        Eigen::Vector3f position_error3;
-        position_error3 << (local_target.x - current_pos.x),
-            (local_target.y - current_pos.y),
-            (local_target.z - current_pos.z);
-
-        // Check for convergence
-        if (position_error3.norm() < tolerance)
-            break;
-
-        // 3x3 Jacobian for position only
-        Eigen::Matrix3f jacobian3 = calculateJacobian(leg, current_angles, p_target);
-
-        // Damped least squares inverse: J_inv = J^T * (J*J^T + λ^2 I)^(-1)
-        Eigen::Matrix3f JJT3 = jacobian3 * jacobian3.transpose();
-        Eigen::Matrix3f identity3 = Eigen::Matrix3f::Identity();
-        Eigen::Matrix3f damped_inv3 = (JJT3 + dls_coefficient * dls_coefficient * identity3).inverse();
-        Eigen::Matrix3f jacobian_inverse3 = jacobian3.transpose() * damped_inv3;
-
-        // Calculate joint angle changes
-        Eigen::Vector3f angle_delta = jacobian_inverse3 * position_error3;
-
-        // Apply adaptive step scaling to prevent large jumps
-        float step_scale = 1.0f;
-        float max_angle_change = 5.0f; // Max 5 degrees per iteration (more conservative)
-        float max_delta = std::max({std::abs(angle_delta(0)), std::abs(angle_delta(1)), std::abs(angle_delta(2))});
-        if (max_delta > math_utils::degreesToRadians(max_angle_change)) {
-            step_scale = math_utils::degreesToRadians(max_angle_change) / max_delta;
-        }
-
-        // Update joint angles (convert from radians to degrees)
-        current_angles.coxa += angle_delta(0) * RADIANS_TO_DEGREES_FACTOR * step_scale;
-        current_angles.femur += angle_delta(1) * RADIANS_TO_DEGREES_FACTOR * step_scale;
-        current_angles.tibia += angle_delta(2) * RADIANS_TO_DEGREES_FACTOR * step_scale;
-
-        // Normalize angles
-        current_angles.coxa = normalizeAngle(current_angles.coxa);
-        current_angles.femur = normalizeAngle(current_angles.femur);
-        current_angles.tibia = normalizeAngle(current_angles.tibia);
-
-        // Apply joint limits
-        current_angles.coxa = constrainAngle(current_angles.coxa, params.coxa_angle_limits[0], params.coxa_angle_limits[1]);
-        current_angles.femur = constrainAngle(current_angles.femur, params.femur_angle_limits[0], params.femur_angle_limits[1]);
-        current_angles.tibia = constrainAngle(current_angles.tibia, params.tibia_angle_limits[0], params.tibia_angle_limits[1]);
-    }
-
-    return current_angles;
+    return result;
 }
 
 Point3D RobotModel::forwardKinematics(int leg_index, const JointAngles &angles) const {

--- a/src/terrain_adaptation.cpp
+++ b/src/terrain_adaptation.cpp
@@ -250,8 +250,11 @@ void TerrainAdaptation::detectTouchdownEvents(int leg_index, const FSRData &fsr_
         float safe_reach = bounds.max_radius * scaling_factors.workspace_scale;
 
         Point3D foot_position;
-        foot_position.x = base_x + safe_reach * cos(math_utils::degreesToRadians(base_angle));
-        foot_position.y = base_y + safe_reach * sin(math_utils::degreesToRadians(base_angle));
+        // Position the foot using only the safe reach from the body centre.
+        // Adding both the hexagon radius and the reach placed the foot well
+        // outside the workspace, resulting in inconsistent servo angles.
+        foot_position.x = safe_reach * cos(math_utils::degreesToRadians(base_angle));
+        foot_position.y = safe_reach * sin(math_utils::degreesToRadians(base_angle));
         foot_position.z = -params.robot_height;
 
         // Configure step plane with detected position and current walk plane normal

--- a/src/walk_controller.cpp
+++ b/src/walk_controller.cpp
@@ -81,36 +81,50 @@ Point3D WalkController::footTrajectory(int leg_index, float phase, float step_he
 
     // Calculate default foot position within reachable workspace
     float leg_reach = p.coxa_length + p.femur_length + p.tibia_length;
+    float min_reach = std::abs(p.femur_length - p.tibia_length);
 
-    // Keep a safety margin so the target remains achievable, 65% of leg reach
-    // This prevents the foot from trying to reach too far during swing phase
-    // and ensures it stays within the leg's reachable workspace
-    // This is especially important for the swing phase where the foot moves
-    // through the air and needs to land safely within the leg's range
-    // Reduced from 75% to 65% to improve IK accuracy at all robot heights
+    // Keep a safety margin so the target remains achievable, 65% of leg reach.
+    // The previous implementation summed the hexagon radius and the safe reach
+    // which could place the target well outside or inside the workspace.  Here
+    // we compute a radial distance that also respects the minimum reachable
+    // distance considering the current robot height.
     float safe_reach = leg_reach * 0.65f;
-    float default_foot_x = base_x + safe_reach * cos(math_utils::degreesToRadians(base_angle));
-    float default_foot_y = base_y + safe_reach * sin(math_utils::degreesToRadians(base_angle));
+    float min_xy = sqrtf(std::max(0.0f, min_reach * min_reach - robot_height * robot_height));
+
+    float desired_radius = std::max(safe_reach,
+                                    p.hexagon_radius + min_xy + step_length * WORKSPACE_SCALING_FACTOR);
+
+    float default_foot_x = desired_radius * cos(math_utils::degreesToRadians(base_angle));
+    float default_foot_y = desired_radius * sin(math_utils::degreesToRadians(base_angle));
 
     if (leg_phase < stance_duration) {
         leg_states[leg_index] = STANCE_PHASE;
         float support_progress = leg_phase / stance_duration;
-        trajectory.x = default_foot_x + step_length * (WORKSPACE_SCALING_FACTOR - support_progress);
-        trajectory.y = default_foot_y;
+        float stance_radius = desired_radius +
+                              step_length * WORKSPACE_SCALING_FACTOR * (1.0f - 2.0f * support_progress);
+        trajectory.x = stance_radius * cos(math_utils::degreesToRadians(base_angle));
+        trajectory.y = stance_radius * sin(math_utils::degreesToRadians(base_angle));
         trajectory.z = -robot_height;
     } else {
         leg_states[leg_index] = SWING_PHASE;
         float swing_progress = (leg_phase - stance_duration) / swing_duration;
 
         Eigen::Vector3f ctrl[5];
-        float start_x = default_foot_x - step_length * WORKSPACE_SCALING_FACTOR;
-        float end_x = default_foot_x + step_length * WORKSPACE_SCALING_FACTOR;
+        float start_radius = std::max(desired_radius - step_length * WORKSPACE_SCALING_FACTOR,
+                                      p.hexagon_radius + min_xy);
+        float end_radius = desired_radius + step_length * WORKSPACE_SCALING_FACTOR;
+        float start_x = start_radius * cos(math_utils::degreesToRadians(base_angle));
+        float end_x = end_radius * cos(math_utils::degreesToRadians(base_angle));
+        float start_y = start_radius * sin(math_utils::degreesToRadians(base_angle));
+        float end_y = end_radius * sin(math_utils::degreesToRadians(base_angle));
         float z_base = -robot_height;
-        ctrl[0] = Eigen::Vector3f(start_x, default_foot_y, z_base);
-        ctrl[1] = Eigen::Vector3f(start_x, default_foot_y, z_base + step_height * WORKSPACE_SCALING_FACTOR);
-        ctrl[2] = Eigen::Vector3f((start_x + end_x) / ANGULAR_ACCELERATION_FACTOR, default_foot_y, z_base + step_height);
-        ctrl[3] = Eigen::Vector3f(end_x, default_foot_y, z_base + step_height * WORKSPACE_SCALING_FACTOR);
-        ctrl[4] = Eigen::Vector3f(end_x, default_foot_y, z_base);
+        ctrl[0] = Eigen::Vector3f(start_x, start_y, z_base);
+        ctrl[1] = Eigen::Vector3f(start_x, start_y, z_base + step_height * WORKSPACE_SCALING_FACTOR);
+        ctrl[2] = Eigen::Vector3f((start_x + end_x) / ANGULAR_ACCELERATION_FACTOR,
+                                  (start_y + end_y) / ANGULAR_ACCELERATION_FACTOR,
+                                  z_base + step_height);
+        ctrl[3] = Eigen::Vector3f(end_x, end_y, z_base + step_height * WORKSPACE_SCALING_FACTOR);
+        ctrl[4] = Eigen::Vector3f(end_x, end_y, z_base);
         Eigen::Vector3f pos = math_utils::quarticBezier(ctrl, swing_progress);
         trajectory.x = pos[0];
         trajectory.y = pos[1];


### PR DESCRIPTION
## Summary
- improve default radius calculations in `WalkController` to keep feet within the reachable workspace
- update terrain adaptation default position logic
- simplify inverse kinematics with a geometric solver for better consistency

## Testing
- `./tests/setup.sh`
- `make tripod_gait_sim_test`
- `./tripod_gait_sim_test`

------
https://chatgpt.com/codex/tasks/task_e_686011549df08323b0476007d66b3ac5