### PR TITLE
Simplify angle math using radians

### DIFF
--- a/src/locomotion_system.cpp
+++ b/src/locomotion_system.cpp
@@ -148,7 +148,9 @@ Point3D LocomotionSystem::calculateForwardKinematics(int leg_index, const JointA
 
 // DH transformation calculation
 Eigen::Matrix4f LocomotionSystem::calculateDHTransform(float a, float alpha, float d, float theta) {
-    return math_utils::dhTransform(a, alpha, d, theta);
+    float alpha_rad = math_utils::degreesToRadians(alpha);
+    float theta_rad = math_utils::degreesToRadians(theta);
+    return math_utils::dhTransform(a, alpha_rad, d, theta_rad);
 }
 
 // Complete leg transform
@@ -210,9 +212,9 @@ Point3D LocomotionSystem::transformWorldToBody(const Point3D &p_world) const {
                 p_world.z - body_position[2]);
 
     // Rotate with negative angles (inverse)
-    Eigen::Vector3f neg_rpy(-body_orientation[0],
-                            -body_orientation[1],
-                            -body_orientation[2]);
+    Eigen::Vector3f neg_rpy(math_utils::degreesToRadians(-body_orientation[0]),
+                            math_utils::degreesToRadians(-body_orientation[1]),
+                            math_utils::degreesToRadians(-body_orientation[2]));
     return math_utils::rotatePoint(rel, neg_rpy);
 }
 

--- a/src/math_utils.cpp
+++ b/src/math_utils.cpp
@@ -80,10 +80,10 @@ Eigen::Vector4f quaternionInverse(const Eigen::Vector4f &q) {
 }
 
 Eigen::Matrix4f dhTransform(float a, float alpha, float d, float theta) {
-    float cos_theta = cos(math_utils::degreesToRadians(theta));
-    float sin_theta = sin(math_utils::degreesToRadians(theta));
-    float cos_alpha = cos(math_utils::degreesToRadians(alpha));
-    float sin_alpha = sin(math_utils::degreesToRadians(alpha));
+    float cos_theta = cos(theta);
+    float sin_theta = sin(theta);
+    float cos_alpha = cos(alpha);
+    float sin_alpha = sin(alpha);
 
     Eigen::Matrix4f transform;
     transform << cos_theta, -sin_theta * cos_alpha, sin_theta * sin_alpha, a * cos_theta,
@@ -111,17 +111,13 @@ Eigen::Vector3f quaternionToEuler(const Eigen::Vector4f &quaternion) {
     float cosy_cosp = 1 - 2 * (y * y + z * z);
     euler[2] = atan2(siny_cosp, cosy_cosp);
 
-    euler[0] = math_utils::radiansToDegrees(euler[0]);
-    euler[1] = math_utils::radiansToDegrees(euler[1]);
-    euler[2] = math_utils::radiansToDegrees(euler[2]);
-
     return euler;
 }
 
 Eigen::Vector4f eulerToQuaternion(const Eigen::Vector3f &euler) {
-    float roll = math_utils::degreesToRadians(euler[0]);
-    float pitch = math_utils::degreesToRadians(euler[1]);
-    float yaw = math_utils::degreesToRadians(euler[2]);
+    float roll = euler[0];
+    float pitch = euler[1];
+    float yaw = euler[2];
 
     float cy = cos(yaw * 0.5);
     float sy = sin(yaw * 0.5);
@@ -140,28 +136,25 @@ Eigen::Vector4f eulerToQuaternion(const Eigen::Vector3f &euler) {
 }
 
 Eigen::Matrix3f rotationMatrixX(float angle) {
-    float rad = math_utils::degreesToRadians(angle);
     Eigen::Matrix3f R;
     R << 1, 0, 0,
-        0, cos(rad), -sin(rad),
-        0, sin(rad), cos(rad);
+        0, cos(angle), -sin(angle),
+        0, sin(angle), cos(angle);
     return R;
 }
 
 Eigen::Matrix3f rotationMatrixY(float angle) {
-    float rad = math_utils::degreesToRadians(angle);
     Eigen::Matrix3f R;
-    R << cos(rad), 0, sin(rad),
+    R << cos(angle), 0, sin(angle),
         0, 1, 0,
-        -sin(rad), 0, cos(rad);
+        -sin(angle), 0, cos(angle);
     return R;
 }
 
 Eigen::Matrix3f rotationMatrixZ(float angle) {
-    float rad = math_utils::degreesToRadians(angle);
     Eigen::Matrix3f R;
-    R << cos(rad), -sin(rad), 0,
-        sin(rad), cos(rad), 0,
+    R << cos(angle), -sin(angle), 0,
+        sin(angle), cos(angle), 0,
         0, 0, 1;
     return R;
 }
@@ -175,8 +168,8 @@ Point3D vector3fToPoint3D(const Eigen::Vector3f &vec) {
     return Point3D(vec[0], vec[1], vec[2]);
 }
 
-Eigen::Vector4f eulerPoint3DToQuaternion(const Point3D &euler_degrees) {
-    Eigen::Vector3f euler_vec = point3DToVector3f(euler_degrees);
+Eigen::Vector4f eulerPoint3DToQuaternion(const Point3D &euler) {
+    Eigen::Vector3f euler_vec = point3DToVector3f(euler);
     return eulerToQuaternion(euler_vec);
 }
 

--- a/src/math_utils.h
+++ b/src/math_utils.h
@@ -12,7 +12,9 @@ float degreesToRadians(float degrees);
 float radiansToDegrees(float radians);
 /** Normalize an angle to the [-180,180] range. */
 float normalizeAngle(float angle);
-/** Rotate a 3D point by roll/pitch/yaw angles. */
+/**
+ * Rotate a 3D point by roll/pitch/yaw angles (radians).
+ */
 Point3D rotatePoint(const Point3D &point, const Eigen::Vector3f &rotation);
 /** Euclidean distance between two points. */
 float distance3D(const Point3D &p1, const Point3D &p2);
@@ -29,16 +31,16 @@ float distance(const Point3D &p1, const Point3D &p2);
 /** Calculate perpendicular distance from point to line segment. */
 float pointToLineDistance(const Point3D &point, const Point3D &line_start, const Point3D &line_end);
 
-/** Rotation matrix about X axis. */
+/** Rotation matrix about X axis (angle in radians). */
 Eigen::Matrix3f rotationMatrixX(float angle);
-/** Rotation matrix about Y axis. */
+/** Rotation matrix about Y axis (angle in radians). */
 Eigen::Matrix3f rotationMatrixY(float angle);
-/** Rotation matrix about Z axis. */
+/** Rotation matrix about Z axis (angle in radians). */
 Eigen::Matrix3f rotationMatrixZ(float angle);
 
-/** Convert quaternion to Euler angles (degrees). */
+/** Convert quaternion to Euler angles (radians). */
 Eigen::Vector3f quaternionToEuler(const Eigen::Vector4f &quaternion);
-/** Convert Euler angles (degrees) to quaternion. */
+/** Convert Euler angles (radians) to quaternion. */
 Eigen::Vector4f eulerToQuaternion(const Eigen::Vector3f &euler);
 /** Multiply two quaternions. */
 Eigen::Vector4f quaternionMultiply(const Eigen::Vector4f &q1, const Eigen::Vector4f &q2);
@@ -49,12 +51,12 @@ Eigen::Vector4f quaternionInverse(const Eigen::Vector4f &q);
 Eigen::Vector3f point3DToVector3f(const Point3D &point);
 /** Convert Eigen::Vector3f to Point3D for pose operations. */
 Point3D vector3fToPoint3D(const Eigen::Vector3f &vec);
-/** Convert Point3D Euler angles to quaternion using centralized functions. */
-Eigen::Vector4f eulerPoint3DToQuaternion(const Point3D &euler_degrees);
-/** Convert quaternion to Point3D Euler angles using centralized functions. */
+/** Convert Point3D Euler angles (radians) to quaternion. */
+Eigen::Vector4f eulerPoint3DToQuaternion(const Point3D &euler);
+/** Convert quaternion to Point3D Euler angles (radians). */
 Point3D quaternionToEulerPoint3D(const Eigen::Vector4f &quaternion);
 
-/** Denavit-Hartenberg transform matrix helper. */
+/** Denavit-Hartenberg transform matrix helper (angles in radians). */
 Eigen::Matrix4f dhTransform(float a, float alpha, float d, float theta);
 
 /**

--- a/src/pose_controller.cpp
+++ b/src/pose_controller.cpp
@@ -149,8 +149,11 @@ bool PoseController::setBodyPoseQuaternion(const Eigen::Vector3f &position, cons
     }
 
     // Original implementation for compatibility
-    Point3D euler_degrees = math_utils::quaternionToEulerPoint3D(quaternion);
-    Eigen::Vector3f orientation = math_utils::point3DToVector3f(euler_degrees);
+    Point3D euler_rad = math_utils::quaternionToEulerPoint3D(quaternion);
+    Eigen::Vector3f orientation(
+        math_utils::radiansToDegrees(euler_rad.x),
+        math_utils::radiansToDegrees(euler_rad.y),
+        math_utils::radiansToDegrees(euler_rad.z));
     return setBodyPose(position, orientation, leg_positions, joint_angles);
 }
 
@@ -225,8 +228,11 @@ bool PoseController::setBodyPoseSmooth(const Eigen::Vector3f &position, const Ei
 bool PoseController::setBodyPoseSmoothQuaternion(const Eigen::Vector3f &position, const Eigen::Vector4f &quaternion,
                                                  Point3D leg_positions[NUM_LEGS], JointAngles joint_angles[NUM_LEGS]) {
     // Convert quaternion to Euler angles and use smooth method
-    Point3D euler_degrees = math_utils::quaternionToEulerPoint3D(quaternion);
-    Eigen::Vector3f orientation = math_utils::point3DToVector3f(euler_degrees);
+    Point3D euler_rad = math_utils::quaternionToEulerPoint3D(quaternion);
+    Eigen::Vector3f orientation(
+        math_utils::radiansToDegrees(euler_rad.x),
+        math_utils::radiansToDegrees(euler_rad.y),
+        math_utils::radiansToDegrees(euler_rad.z));
     return setBodyPoseSmooth(position, orientation, leg_positions, joint_angles);
 }
 
@@ -393,7 +399,10 @@ bool PoseController::setBodyPoseImmediate(const Eigen::Vector3f &position, const
 
         // Apply body transformation: translate relative to body position, then rotate
         Point3D leg_body_relative(stance_pos.x - position[0], stance_pos.y - position[1], stance_pos.z - position[2]);
-        Point3D leg_rotated = math_utils::rotatePoint(leg_body_relative, orientation);
+        Eigen::Vector3f orientation_rad(math_utils::degreesToRadians(orientation[0]),
+                                       math_utils::degreesToRadians(orientation[1]),
+                                       math_utils::degreesToRadians(orientation[2]));
+        Point3D leg_rotated = math_utils::rotatePoint(leg_body_relative, orientation_rad);
         Point3D leg_world(position[0] + leg_rotated.x,
                           position[1] + leg_rotated.y,
                           position[2] + leg_rotated.z);

--- a/src/robot_model.cpp
+++ b/src/robot_model.cpp
@@ -199,7 +199,9 @@ Eigen::Matrix4f RobotModel::legTransform(int leg_index, const JointAngles &q) co
         float d = dh_transforms[leg_index][j][2];      // link offset
         float theta0 = dh_transforms[leg_index][j][3]; // joint angle offset
         float theta = theta0 + joint_deg[j];           // total joint angle
-        T *= math_utils::dhTransform(a, alpha, d, theta);
+        float alpha_rad = math_utils::degreesToRadians(alpha);
+        float theta_rad = math_utils::degreesToRadians(theta);
+        T *= math_utils::dhTransform(a, alpha_rad, d, theta_rad);
     }
 
     return T;
@@ -231,7 +233,10 @@ Eigen::Matrix3f RobotModel::calculateJacobian(int leg, const JointAngles &q, con
         float theta0 = dh_transforms[leg][j][3]; // joint angle offset
         float theta = theta0 + joint_deg[j];     // total joint angle
 
-        transforms[j + 1] = transforms[j] * math_utils::dhTransform(a, alpha, d, theta);
+        float alpha_rad = math_utils::degreesToRadians(alpha);
+        float theta_rad = math_utils::degreesToRadians(theta);
+
+        transforms[j + 1] = transforms[j] * math_utils::dhTransform(a, alpha_rad, d, theta_rad);
     }
 
     // End-effector transform

--- a/tests/math_utils_test.cpp
+++ b/tests/math_utils_test.cpp
@@ -8,7 +8,7 @@ int main() {
     float rad = degreesToRadians(deg);
     assert(static_cast<int>(radiansToDegrees(rad)) == 90);
 
-    auto R = rotationMatrixZ(45.0f);
+    auto R = rotationMatrixZ(degreesToRadians(45.0f));
     Eigen::Matrix3f I = R * R.transpose();
     assert((I - Eigen::Matrix3f::Identity()).norm() < 1e-5);
     std::cout << "math_utils_test executed successfully" << std::endl;

--- a/tests/quaternion_functions_test.cpp
+++ b/tests/quaternion_functions_test.cpp
@@ -6,17 +6,25 @@ int main() {
     std::cout << "=== Test quaternion functions in math_utils ===" << std::endl;
 
     // Test eulerToQuaternion and quaternionToEuler
-    Eigen::Vector3f euler_input(30.0f, 45.0f, 60.0f); // degrees
+    Eigen::Vector3f euler_input_deg(30.0f, 45.0f, 60.0f);
+    Eigen::Vector3f euler_input(
+        math_utils::degreesToRadians(euler_input_deg[0]),
+        math_utils::degreesToRadians(euler_input_deg[1]),
+        math_utils::degreesToRadians(euler_input_deg[2]));
     Eigen::Vector4f quat = math_utils::eulerToQuaternion(euler_input);
     Eigen::Vector3f euler_output = math_utils::quaternionToEuler(quat);
+    Eigen::Vector3f euler_output_deg(
+        math_utils::radiansToDegrees(euler_output[0]),
+        math_utils::radiansToDegrees(euler_output[1]),
+        math_utils::radiansToDegrees(euler_output[2]));
 
-    std::cout << "Input Euler (deg): " << euler_input.transpose() << std::endl;
+    std::cout << "Input Euler (deg): " << euler_input_deg.transpose() << std::endl;
     std::cout << "Quaternion: " << quat.transpose() << std::endl;
-    std::cout << "Output Euler (deg): " << euler_output.transpose() << std::endl;
+    std::cout << "Output Euler (deg): " << euler_output_deg.transpose() << std::endl;
 
     // Check if conversion is consistent
     float tolerance = 0.01f;
-    bool conversion_ok = (euler_input - euler_output).norm() < tolerance;
+    bool conversion_ok = (euler_input_deg - euler_output_deg).norm() < tolerance;
     std::cout << "Euler<->Quaternion conversion: " << (conversion_ok ? "PASS" : "FAIL") << std::endl;
 
     // Test quaternionMultiply

--- a/tests/quaternion_pose_system_test.cpp
+++ b/tests/quaternion_pose_system_test.cpp
@@ -28,17 +28,23 @@ int main() {
     std::cout << "\n1. Testing quaternion conversion functions..." << std::endl;
 
     // Test conversion functions
-    Point3D euler_test(30.0f, 45.0f, 60.0f); // degrees
+    Point3D euler_test_deg(30.0f, 45.0f, 60.0f);
+    Point3D euler_test(math_utils::degreesToRadians(euler_test_deg.x),
+                       math_utils::degreesToRadians(euler_test_deg.y),
+                       math_utils::degreesToRadians(euler_test_deg.z));
     Eigen::Vector4f quat_test = math_utils::eulerPoint3DToQuaternion(euler_test);
-    Point3D euler_back = math_utils::quaternionToEulerPoint3D(quat_test);
+    Point3D euler_back_rad = math_utils::quaternionToEulerPoint3D(quat_test);
+    Point3D euler_back(math_utils::radiansToDegrees(euler_back_rad.x),
+                       math_utils::radiansToDegrees(euler_back_rad.y),
+                       math_utils::radiansToDegrees(euler_back_rad.z));
 
-    std::cout << "Original Euler: (" << euler_test.x << ", " << euler_test.y << ", " << euler_test.z << ")" << std::endl;
+    std::cout << "Original Euler: (" << euler_test_deg.x << ", " << euler_test_deg.y << ", " << euler_test_deg.z << ")" << std::endl;
     std::cout << "Quaternion: (" << quat_test[0] << ", " << quat_test[1] << ", " << quat_test[2] << ", " << quat_test[3] << ")" << std::endl;
     std::cout << "Converted back: (" << euler_back.x << ", " << euler_back.y << ", " << euler_back.z << ")" << std::endl;
 
-    float conversion_error = std::abs(euler_test.x - euler_back.x) +
-                             std::abs(euler_test.y - euler_back.y) +
-                             std::abs(euler_test.z - euler_back.z);
+    float conversion_error = std::abs(euler_test_deg.x - euler_back.x) +
+                             std::abs(euler_test_deg.y - euler_back.y) +
+                             std::abs(euler_test_deg.z - euler_back.z);
     std::cout << "Conversion error: " << conversion_error << " degrees" << std::endl;
     std::cout << "Conversion test: " << (conversion_error < 0.1f ? "PASS" : "FAIL") << std::endl;
 


### PR DESCRIPTION
## Summary
- update math utilities to operate in radians
- convert quaternion helpers and rotation matrices to radian input/output
- adapt pose and locomotion controllers for new radian math
- adjust DH transform usage
- fix unit tests for radian interfaces

## Testing
- `./setup.sh`
- `make` *(fails: undefined reference to WorkspaceValidator)*

------
https://chatgpt.com/codex/tasks/task_e_6860e5aa2b9c8323a6a5a6586e8744f3