### PR TITLE
Simplify kinematic routines

### DIFF
--- a/src/HexaModel.h
+++ b/src/HexaModel.h
@@ -36,7 +36,11 @@ struct Parameters {
     float angle_sign_tibia = 1.0f; ///< Sign multiplier for tibia joint output (+1.0 or -1.0 to match servo direction)
 
     bool use_custom_dh_parameters = false; ///< Use custom Denavit-Hartenberg parameters
-    float dh_parameters[NUM_LEGS][DOF_PER_LEG][4];
+    /**
+     * @brief DH parameter table for each leg.
+     * The first entry represents the fixed base transform.
+     */
+    float dh_parameters[NUM_LEGS][DOF_PER_LEG + 1][4];
 
     Eigen::Vector3f imu_calibration_offset;
     float fsr_touchdown_threshold;
@@ -363,8 +367,9 @@ class RobotModel {
 
   private:
     const Parameters &params;
-    // DH parameter table: [leg][joint][param] where param = [a, alpha, d, theta_offset]
-    float dh_transforms[NUM_LEGS][DOF_PER_LEG][4];
+    // DH parameter table: [leg][index][param] where index=0 is the base
+    // transform and param = [a, alpha, d, theta_offset]
+    float dh_transforms[NUM_LEGS][DOF_PER_LEG + 1][4];
 };
 
 #endif // MODEL_H

--- a/src/robot_model.cpp
+++ b/src/robot_model.cpp
@@ -17,28 +17,33 @@ void RobotModel::initializeDH() {
 
     // Use default DH parameters if no custom parameters provided
     if (!params.use_custom_dh_parameters) {
-        // Per-leg base joint (coxa) theta offsets in degrees, representing each leg's mounting orientation
-        // around the hexagonal body (legs spaced 60° apart, starting at front-right)
+        // Per-leg base orientations around the hexagonal body (degrees)
         static const float base_theta_offsets[NUM_LEGS] = {
             0.0f, -60.0f, -120.0f, 180.0f, 120.0f, 60.0f};
         for (int l = 0; l < NUM_LEGS; ++l) {
-            // Joint 1 (coxa): vertical axis rotation
-            dh_transforms[l][0][0] = params.coxa_length;    // a0 - coxa length
-            dh_transforms[l][0][1] = 90.0f;                 // alpha0 - rotate to femur axis
-            dh_transforms[l][0][2] = 0.0f;                  // d1 - link offset
-            dh_transforms[l][0][3] = base_theta_offsets[l]; // theta1 offset - mounting offset
+            // Base transform from body center to leg mount
+            dh_transforms[l][0][0] = params.hexagon_radius; // a
+            dh_transforms[l][0][1] = 0.0f;                 // alpha
+            dh_transforms[l][0][2] = 0.0f;                 // d
+            dh_transforms[l][0][3] = base_theta_offsets[l]; // theta
 
-            // Joint 2 (femur): pitch axis rotation
-            dh_transforms[l][1][0] = params.femur_length; // a1 - femur length
-            dh_transforms[l][1][1] = 0.0f;                // alpha1 - twist angle
-            dh_transforms[l][1][2] = 0.0f;                // d2 - link offset
-            dh_transforms[l][1][3] = 0.0f;                // theta2 offset - joint angle offset
+            // Coxa link
+            dh_transforms[l][1][0] = params.coxa_length; // a
+            dh_transforms[l][1][1] = 90.0f;              // alpha
+            dh_transforms[l][1][2] = 0.0f;               // d
+            dh_transforms[l][1][3] = 0.0f;               // theta offset
 
-            // Joint 3 (tibia): pitch axis rotation
-            dh_transforms[l][2][0] = params.tibia_length; // a2 - tibia length
-            dh_transforms[l][2][1] = 0.0f;                // alpha2 - twist angle
-            dh_transforms[l][2][2] = 0.0f;                // d3 - link offset
-            dh_transforms[l][2][3] = -90.0f;              // theta3 offset - knee offset
+            // Femur link
+            dh_transforms[l][2][0] = params.femur_length; // a
+            dh_transforms[l][2][1] = 0.0f;               // alpha
+            dh_transforms[l][2][2] = 0.0f;               // d
+            dh_transforms[l][2][3] = 0.0f;               // theta offset
+
+            // Tibia link
+            dh_transforms[l][3][0] = params.tibia_length; // a
+            dh_transforms[l][3][1] = 0.0f;               // alpha
+            dh_transforms[l][3][2] = 0.0f;               // d
+            dh_transforms[l][3][3] = -90.0f;             // theta offset
         }
     }
 }
@@ -48,14 +53,15 @@ void RobotModel::initializeDH() {
 JointAngles RobotModel::inverseKinematics(int leg, const Point3D &p_target) {
 
     // Transform target to leg coordinate system
-    const float base_angle_deg = leg * LEG_ANGLE_SPACING;
-    float base_x = params.hexagon_radius * cos(math_utils::degreesToRadians(base_angle_deg));
-    float base_y = params.hexagon_radius * sin(math_utils::degreesToRadians(base_angle_deg));
+    Eigen::Matrix4f T_base = math_utils::dhTransform(
+        dh_transforms[leg][0][0],
+        dh_transforms[leg][0][1],
+        dh_transforms[leg][0][2],
+        dh_transforms[leg][0][3]);
+    Eigen::Vector4f target_vec(p_target.x, p_target.y, p_target.z, 1.0f);
+    Eigen::Vector4f local_vec = T_base.inverse() * target_vec;
 
-    Point3D local_target;
-    local_target.x = p_target.x - base_x;
-    local_target.y = p_target.y - base_y;
-    local_target.z = p_target.z;
+    Point3D local_target(local_vec(0), local_vec(1), local_vec(2));
 
     // Quick workspace check using centralized reachability function
     float max_reach = params.coxa_length + params.femur_length + params.tibia_length;
@@ -77,177 +83,46 @@ JointAngles RobotModel::inverseKinematics(int leg, const Point3D &p_target) {
         }
     }
 
-    /*
-     * MULTIPLE STARTING CONFIGURATIONS APPROACH:
-     *
-     * This implementation differs from the original CSIRO syropod_highlevel_controller
-     * by using multiple starting configurations to improve convergence robustness.
-     *
-     * RATIONALE:
-     * - The original CSIRO implementation uses a single initial guess for DLS iteration
-     * - For challenging targets (near singularities, workspace boundaries, multiple solutions),
-     *   a single starting point may fail to converge or converge to suboptimal solutions
-     * - This enhanced approach tries up to 5 different starting configurations to find
-     *   the best solution within joint limits
-     *
-     * CONFIGURATIONS TRIED:
-     * 1. Target-oriented pose (-45°, 60°) - typical walking configuration
-     * 2. High pose (30°, -60°) - leg raised up
-     * 3. Mid pose (-30°, 45°) - intermediate position
-     * 4. Straight pose (0°, 0°) - fully extended
-     * 5. Extended pose (-60°, 80°) - maximum reach
-     *
-     * DISABLE WITH: Set params.ik.use_multiple_starts = false to use original CSIRO behavior
-     */
-
-    // Try multiple starting positions for challenging cases
-    JointAngles best_result;
-    float best_error = std::numeric_limits<float>::max();
-
-    // Define starting configurations based on user preference
-    std::vector<JointAngles> starting_configs;
     float coxa_start = atan2(local_target.y, local_target.x) * RADIANS_TO_DEGREES_FACTOR;
     coxa_start = constrainAngle(coxa_start, params.coxa_angle_limits[0], params.coxa_angle_limits[1]);
+    JointAngles current_angles(coxa_start, IK_PRIMARY_FEMUR_ANGLE, IK_PRIMARY_TIBIA_ANGLE);
 
-    if (params.ik.use_multiple_starts) {
-        // Enhanced approach: Multiple starting configurations for better convergence
-        starting_configs.push_back(JointAngles(coxa_start, IK_PRIMARY_FEMUR_ANGLE, IK_PRIMARY_TIBIA_ANGLE));   // Primary guess
-        starting_configs.push_back(JointAngles(coxa_start, IK_HIGH_FEMUR_ANGLE, IK_HIGH_TIBIA_ANGLE));         // High pose
-        starting_configs.push_back(JointAngles(coxa_start, -30.0f, 45.0f));                                    // Mid pose
-        starting_configs.push_back(JointAngles(coxa_start, 0.0f, 0.0f));                                       // Straight pose
-        starting_configs.push_back(JointAngles(coxa_start, IK_EXTENDED_FEMUR_ANGLE, IK_EXTENDED_TIBIA_ANGLE)); // Extended pose
-    } else {
-        // Original CSIRO approach: Single starting configuration
-        starting_configs.push_back(JointAngles(coxa_start, IK_PRIMARY_FEMUR_ANGLE, IK_PRIMARY_TIBIA_ANGLE));
-    }
+    for (int iter = 0; iter < IK_MAX_ITERATIONS; ++iter) {
+        Point3D current_pos = forwardKinematics(leg, current_angles);
 
-    // Try each starting configuration
-    for (const auto &start_config : starting_configs) {
-        JointAngles current_angles = start_config;
+        Eigen::Vector3f position_delta;
+        position_delta << (local_target.x - current_pos.x),
+            (local_target.y - current_pos.y),
+            (local_target.z - current_pos.z);
 
-        // Clamp starting angles to joint limits
-        current_angles.coxa = constrainAngle(current_angles.coxa, params.coxa_angle_limits[0], params.coxa_angle_limits[1]);
-        current_angles.femur = constrainAngle(current_angles.femur, params.femur_angle_limits[0], params.femur_angle_limits[1]);
-        current_angles.tibia = constrainAngle(current_angles.tibia, params.tibia_angle_limits[0], params.tibia_angle_limits[1]);
-
-        float previous_error = std::numeric_limits<float>::max();
-        float stagnation_threshold = IK_STAGNATION_THRESHOLD; // If error doesn't improve by this much, consider stagnant
-        int stagnation_count = 0;
-
-        for (int iter = 0; iter < IK_MAX_ITERATIONS; ++iter) {
-            // Calculate current end-effector position using forward kinematics
-            Point3D current_pos = forwardKinematics(leg, current_angles);
-
-            // Calculate position error (delta)
-            Eigen::Vector3f position_delta;
-            position_delta << (local_target.x - current_pos.x),
-                (local_target.y - current_pos.y),
-                (local_target.z - current_pos.z);
-
-            // Check for convergence
-            float error_norm = position_delta.norm();
-            if (error_norm < IK_TOLERANCE * POSITION_TOLERANCE) {
-                // Found good solution, record it and break from both loops
-                best_result = current_angles;
-                best_error = error_norm;
-                goto solution_found;
-            }
-
-            // Check for stagnation (not making progress)
-            if (previous_error - error_norm < stagnation_threshold) {
-                stagnation_count++;
-                if (stagnation_count > IK_STAGNATION_COUNT_MAX) {
-                    // Algorithm is stagnating, break from inner loop to try next start
-                    break;
-                }
-            } else {
-                stagnation_count = 0; // Reset if making progress
-            }
-            previous_error = error_norm;
-
-            // Calculate Jacobian matrix using DH parameters
-            Eigen::Matrix3f jacobian = calculateJacobian(leg, current_angles, p_target);
-
-            // Check for singular configuration (determinant near zero)
-            float det = jacobian.determinant();
-            if (std::abs(det) < IK_SINGULAR_THRESHOLD) {
-                // Near singular configuration, increase damping
-                const float high_damping = IK_HIGH_DAMPING;
-                Eigen::Matrix3f JJT = jacobian * jacobian.transpose();
-                Eigen::Matrix3f identity = Eigen::Matrix3f::Identity();
-                Eigen::Matrix3f damped_inv = (JJT + high_damping * high_damping * identity).inverse();
-                Eigen::Matrix3f jacobian_inverse = jacobian.transpose() * damped_inv;
-
-                // Calculate joint angle changes with smaller step
-                Eigen::Vector3f angle_delta = jacobian_inverse * position_delta * IK_STEP_SIZE_REDUCTION;
-
-                // Convert to degrees and update joint angles
-                current_angles.coxa += angle_delta(0) * RADIANS_TO_DEGREES_FACTOR;
-                current_angles.femur += angle_delta(1) * RADIANS_TO_DEGREES_FACTOR;
-                current_angles.tibia += angle_delta(2) * RADIANS_TO_DEGREES_FACTOR;
-
-                // Normalize angles to handle wraparound
-                current_angles.coxa = normalizeAngle(current_angles.coxa);
-                current_angles.femur = normalizeAngle(current_angles.femur);
-                current_angles.tibia = normalizeAngle(current_angles.tibia);
-            } else {
-                // Apply standard Damped Least Squares method
-                // J_inv = J^T * (J * J^T + λ^2 * I)^(-1)
-                Eigen::Matrix3f JJT = jacobian * jacobian.transpose();
-                Eigen::Matrix3f identity = Eigen::Matrix3f::Identity();
-                Eigen::Matrix3f damped_inv = (JJT + IK_DLS_COEFFICIENT * IK_DLS_COEFFICIENT * identity).inverse();
-                Eigen::Matrix3f jacobian_inverse = jacobian.transpose() * damped_inv;
-
-                // Calculate joint angle changes
-                Eigen::Vector3f angle_delta = jacobian_inverse * position_delta;
-
-                // Convert to degrees and update joint angles
-                current_angles.coxa += angle_delta(0) * RADIANS_TO_DEGREES_FACTOR;
-                current_angles.femur += angle_delta(1) * RADIANS_TO_DEGREES_FACTOR;
-                current_angles.tibia += angle_delta(2) * RADIANS_TO_DEGREES_FACTOR;
-
-                // Normalize angles to handle wraparound
-                current_angles.coxa = normalizeAngle(current_angles.coxa);
-                current_angles.femur = normalizeAngle(current_angles.femur);
-                current_angles.tibia = normalizeAngle(current_angles.tibia);
-            }
-
-            // Apply joint limits
-            if (params.ik.clamp_joints) {
-                current_angles.coxa = constrainAngle(current_angles.coxa, params.coxa_angle_limits[0], params.coxa_angle_limits[1]);
-                current_angles.femur = constrainAngle(current_angles.femur, params.femur_angle_limits[0], params.femur_angle_limits[1]);
-                current_angles.tibia = constrainAngle(current_angles.tibia, params.tibia_angle_limits[0], params.tibia_angle_limits[1]);
-            }
+        if (position_delta.norm() < IK_TOLERANCE * POSITION_TOLERANCE) {
+            break;
         }
 
-        // Check if this attempt gave a better result than previous ones
-        Point3D final_pos = forwardKinematics(leg, current_angles);
-        float final_error = sqrt(pow(p_target.x - final_pos.x, 2) +
-                                 pow(p_target.y - final_pos.y, 2) +
-                                 pow(p_target.z - final_pos.z, 2));
+        Eigen::Matrix3f jacobian = calculateJacobian(leg, current_angles, p_target);
+        Eigen::Matrix3f JJT = jacobian * jacobian.transpose();
+        Eigen::Matrix3f identity = Eigen::Matrix3f::Identity();
+        Eigen::Matrix3f damped_inv = (JJT + IK_DLS_COEFFICIENT * IK_DLS_COEFFICIENT * identity).inverse();
+        Eigen::Matrix3f jacobian_inverse = jacobian.transpose() * damped_inv;
 
-        // Prefer solutions with better accuracy, but also consider if solution is within joint limits
-        bool current_within_limits = checkJointLimits(leg, current_angles);
-        bool best_within_limits = checkJointLimits(leg, best_result);
+        Eigen::Vector3f angle_delta = jacobian_inverse * position_delta;
 
-        bool update_best = false;
-        if (current_within_limits && !best_within_limits) {
-            // Current solution is within limits, best is not - prefer current
-            update_best = true;
-        } else if (current_within_limits == best_within_limits) {
-            // Both have same limit status - prefer better accuracy
-            update_best = (final_error < best_error);
-        }
-        // If current is outside limits but best is within limits, don't update
+        current_angles.coxa += angle_delta(0) * RADIANS_TO_DEGREES_FACTOR;
+        current_angles.femur += angle_delta(1) * RADIANS_TO_DEGREES_FACTOR;
+        current_angles.tibia += angle_delta(2) * RADIANS_TO_DEGREES_FACTOR;
 
-        if (update_best) {
-            best_result = current_angles;
-            best_error = final_error;
+        current_angles.coxa = normalizeAngle(current_angles.coxa);
+        current_angles.femur = normalizeAngle(current_angles.femur);
+        current_angles.tibia = normalizeAngle(current_angles.tibia);
+
+        if (params.ik.clamp_joints) {
+            current_angles.coxa = constrainAngle(current_angles.coxa, params.coxa_angle_limits[0], params.coxa_angle_limits[1]);
+            current_angles.femur = constrainAngle(current_angles.femur, params.femur_angle_limits[0], params.femur_angle_limits[1]);
+            current_angles.tibia = constrainAngle(current_angles.tibia, params.tibia_angle_limits[0], params.tibia_angle_limits[1]);
         }
     }
 
-solution_found:
-    return best_result;
+    return current_angles;
 }
 
 Point3D RobotModel::forwardKinematics(int leg_index, const JointAngles &angles) const {
@@ -260,21 +135,21 @@ Point3D RobotModel::forwardKinematics(int leg_index, const JointAngles &angles) 
 }
 
 Eigen::Matrix4f RobotModel::legTransform(int leg_index, const JointAngles &q) const {
-    const float base_angle_deg = leg_index * LEG_ANGLE_SPACING;
-    Eigen::Matrix4f T = Eigen::Matrix4f::Identity();
-    T(0, 3) = params.hexagon_radius * cos(math_utils::degreesToRadians(base_angle_deg));
-    T(1, 3) = params.hexagon_radius * sin(math_utils::degreesToRadians(base_angle_deg));
-    T.block<3, 3>(0, 0) = math_utils::rotationMatrixZ(base_angle_deg);
+    Eigen::Matrix4f T = math_utils::dhTransform(
+        dh_transforms[leg_index][0][0],
+        dh_transforms[leg_index][0][1],
+        dh_transforms[leg_index][0][2],
+        dh_transforms[leg_index][0][3]);
 
     const float joint_deg[DOF_PER_LEG] = {q.coxa, q.femur, q.tibia};
 
-    for (int j = 0; j < DOF_PER_LEG; ++j) {
+    for (int j = 1; j <= DOF_PER_LEG; ++j) {
         // Extract DH parameters for this joint
         float a = dh_transforms[leg_index][j][0];      // link length
         float alpha = dh_transforms[leg_index][j][1];  // twist angle
         float d = dh_transforms[leg_index][j][2];      // link offset
         float theta0 = dh_transforms[leg_index][j][3]; // joint angle offset
-        float theta = theta0 + joint_deg[j];           // total joint angle
+        float theta = theta0 + joint_deg[j - 1];       // total joint angle
         T *= math_utils::dhTransform(a, alpha, d, theta);
     }
 
@@ -285,29 +160,27 @@ Eigen::Matrix3f RobotModel::calculateJacobian(int leg, const JointAngles &q, con
     // Calculate Jacobian from DH matrices along kinematic chain
     // Based on syropod_highlevel_controller implementation
 
-    // Get base transform for this leg
-    const float base_angle_deg = leg * LEG_ANGLE_SPACING;
-    Eigen::Matrix4f T_base = Eigen::Matrix4f::Identity();
-    T_base(0, 3) = params.hexagon_radius * cos(math_utils::degreesToRadians(base_angle_deg));
-    T_base(1, 3) = params.hexagon_radius * sin(math_utils::degreesToRadians(base_angle_deg));
-    T_base.block<3, 3>(0, 0) = math_utils::rotationMatrixZ(base_angle_deg);
-
     // Calculate transforms and positions for each joint
     std::vector<Eigen::Matrix4f> transforms(DOF_PER_LEG + 1);
-    transforms[0] = T_base;
+
+    // Base transform
+    transforms[0] = math_utils::dhTransform(
+        dh_transforms[leg][0][0],
+        dh_transforms[leg][0][1],
+        dh_transforms[leg][0][2],
+        dh_transforms[leg][0][3]);
 
     const float joint_deg[DOF_PER_LEG] = {q.coxa, q.femur, q.tibia};
 
     // Build transforms step by step using DH parameters
-    for (int j = 0; j < DOF_PER_LEG; ++j) {
-        // Extract DH parameters for this joint
-        float a = dh_transforms[leg][j][0];      // link length
-        float alpha = dh_transforms[leg][j][1];  // twist angle
-        float d = dh_transforms[leg][j][2];      // link offset
-        float theta0 = dh_transforms[leg][j][3]; // joint angle offset
-        float theta = theta0 + joint_deg[j];     // total joint angle
+    for (int j = 1; j <= DOF_PER_LEG; ++j) {
+        float a = dh_transforms[leg][j][0];
+        float alpha = dh_transforms[leg][j][1];
+        float d = dh_transforms[leg][j][2];
+        float theta0 = dh_transforms[leg][j][3];
+        float theta = theta0 + joint_deg[j - 1];
 
-        transforms[j + 1] = transforms[j] * math_utils::dhTransform(a, alpha, d, theta);
+        transforms[j] = transforms[j - 1] * math_utils::dhTransform(a, alpha, d, theta);
     }
 
     // End-effector transform


### PR DESCRIPTION
## Summary
- expand DH parameter table to include base transform
- rely exclusively on DH parameters in RobotModel initialization
- rewrite inverseKinematics with a single DLS loop
- update legTransform and Jacobian to use DH tables directly

## Testing
- `tests/setup.sh`
- `make` *(fails: error in `tripod_gait_sim_test.cpp`)*

------
https://chatgpt.com/codex/tasks/task_e_68616742767883238e338861515a2d72