### PR TITLE
Refine DH table and DLS implementation

### DIFF
--- a/src/HexaModel.h
+++ b/src/HexaModel.h
@@ -36,7 +36,11 @@ struct Parameters {
     float angle_sign_tibia = 1.0f; ///< Sign multiplier for tibia joint output (+1.0 or -1.0 to match servo direction)
 
     bool use_custom_dh_parameters = false; ///< Use custom Denavit-Hartenberg parameters
-    float dh_parameters[NUM_LEGS][DOF_PER_LEG][4];
+    /**
+     * @brief DH parameter table for each leg.
+     * The first entry represents the fixed base transform.
+     */
+    float dh_parameters[NUM_LEGS][DOF_PER_LEG + 1][4];
 
     Eigen::Vector3f imu_calibration_offset;
     float fsr_touchdown_threshold;
@@ -364,7 +368,8 @@ class RobotModel {
   private:
     const Parameters &params;
     // DH parameter table: [leg][joint][param] where param = [a, alpha, d, theta_offset]
-    float dh_transforms[NUM_LEGS][DOF_PER_LEG][4];
+    // The first entry stores the fixed base transform for the leg
+    float dh_transforms[NUM_LEGS][DOF_PER_LEG + 1][4];
 };
 
 #endif // MODEL_H

--- a/tests/actual_workspace_test.cpp
+++ b/tests/actual_workspace_test.cpp
@@ -22,7 +22,7 @@ int main() {
 
     // Initialize DH parameters
     for (int l = 0; l < NUM_LEGS; ++l) {
-        for (int j = 0; j < DOF_PER_LEG; ++j) {
+        for (int j = 0; j < DOF_PER_LEG + 1; ++j) {
             for (int k = 0; k < 4; ++k) {
                 params.dh_parameters[l][j][k] = 0.0f;
             }

--- a/tests/dls_validation_test.cpp
+++ b/tests/dls_validation_test.cpp
@@ -22,7 +22,7 @@ int main() {
 
     // Initialize DH parameters to zero (will use default)
     for (int l = 0; l < NUM_LEGS; ++l) {
-        for (int j = 0; j < DOF_PER_LEG; ++j) {
+        for (int j = 0; j < DOF_PER_LEG + 1; ++j) {
             for (int k = 0; k < 4; ++k) {
                 params.dh_parameters[l][j][k] = 0.0f;
             }

--- a/tests/ik_fk_validation_test.cpp
+++ b/tests/ik_fk_validation_test.cpp
@@ -318,7 +318,7 @@ int main() {
     // Initialize DH parameters
     params.use_custom_dh_parameters = false;
     for (int l = 0; l < NUM_LEGS; ++l) {
-        for (int j = 0; j < DOF_PER_LEG; ++j) {
+        for (int j = 0; j < DOF_PER_LEG + 1; ++j) {
             for (int k = 0; k < 4; ++k) {
                 params.dh_parameters[l][j][k] = 0.0f;
             }

--- a/tests/test3_analysis.cpp
+++ b/tests/test3_analysis.cpp
@@ -20,7 +20,7 @@ int main() {
 
     // Initialize DH parameters
     for (int l = 0; l < NUM_LEGS; ++l) {
-        for (int j = 0; j < DOF_PER_LEG; ++j) {
+        for (int j = 0; j < DOF_PER_LEG + 1; ++j) {
             for (int k = 0; k < 4; ++k) {
                 params.dh_parameters[l][j][k] = 0.0f;
             }

--- a/tests/workspace_analysis.cpp
+++ b/tests/workspace_analysis.cpp
@@ -22,7 +22,7 @@ int main() {
 
     // Initialize DH parameters to zero (will use default)
     for (int l = 0; l < NUM_LEGS; ++l) {
-        for (int j = 0; j < DOF_PER_LEG; ++j) {
+        for (int j = 0; j < DOF_PER_LEG + 1; ++j) {
             for (int k = 0; k < 4; ++k) {
                 params.dh_parameters[l][j][k] = 0.0f;
             }


### PR DESCRIPTION
## Summary
- expand DH parameter table to include base transform
- initialize leg links based on real robot geometry
- use base orientation offsets for IK and FK
- update DLS solver to build transforms from DH table
- adjust tests for new DH table layout

## Testing
- `tests/setup.sh`
- `make` *(fails: undefined reference to `WorkspaceValidator`)*

------
https://chatgpt.com/codex/tasks/task_e_68617b228b688323b81977ecc25f13d6