### PR TITLE
Fix IK/FK consistency in simple_ik_test

### DIFF
--- a/tests/simple_ik_test.cpp
+++ b/tests/simple_ik_test.cpp
@@ -57,11 +57,13 @@ int main() {
     bool height_ok = true;
     for (int leg = 0; leg < NUM_LEGS; ++leg) {
 
-        // Start angles are the same as the base_theta_offsets
-        JointAngles test_angles(base_theta_offsets[leg], 20, 20);
+        // Use the same relative joint angles for every leg; the base offset is
+        // already accounted for in the DH model
+        JointAngles test_angles(0, 20, 20);
         Point3D target = model.forwardKinematics(leg, test_angles);
 
-        JointAngles start_angles(base_theta_offsets[leg], 0, 0); // Test symmetric configuration
+        // Provide a neutral starting guess
+        JointAngles start_angles(0, 0, 0);
         JointAngles ik = model.inverseKinematicsCurrent(leg, start_angles, target);
         Point3D fk = model.forwardKinematics(leg, ik);
         printf("target: %f, %f, %f\n", target.x, target.y, target.z);


### PR DESCRIPTION
## Summary
- use relative joint angles instead of duplicating the base offset
- give a neutral starting guess for the IK solver

This corrects the IK/FK coherence validation.

## Testing
- `g++ -std=c++17 -I../src -I. -I/usr/include/eigen3 ../src/robot_model.cpp ../src/math_utils.cpp simple_ik_test.cpp -o simple_ik_test -DEIGEN_DONT_VECTORIZE -DEIGEN_DISABLE_UNALIGNED_ARRAY_ASSERT`
- `./simple_ik_test`

------
https://chatgpt.com/codex/tasks/task_e_68634fa6262c8323ba3c8f928f196380