### PR TITLE
Fix missing build dependency

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,7 +7,7 @@ EIGEN_PATH := /usr/include/eigen3
 endif
 CXXFLAGS=-I../src -I. -I$(EIGEN_PATH) -std=c++17
 
-SOURCES = ../src/math_utils.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/manual_pose_controller.cpp ../src/state_controller.cpp ../src/locomotion_system.cpp ../src/cartesian_velocity_controller.cpp
+SOURCES = ../src/math_utils.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/manual_pose_controller.cpp ../src/state_controller.cpp ../src/locomotion_system.cpp ../src/cartesian_velocity_controller.cpp ../src/workspace_validator.cpp
 
 all: math_utils_test model_test pose_controller_test walk_controller_test admittance_controller_test locomotion_system_test state_controller_test cruise_control_comprehensive_test tripod_gait_sim_test height_range_test geometry_test dls_validation_test workspace_analysis actual_workspace_test angle_range_test edge_case_analysis angle_normalization_test terrain_adaptation_test fsr_threshold_test velocity_limits_test state_controller_runtime_test openshc_equivalent_features_test full_feature_sim_test test_metachronal_adaptive_gaits final_validation_test quaternion_pose_system_test quaternion_functions_test pose_control_comprehensive_test pose_control_equivalence_test absolute_positioning_compile_test admittance_derivatives_test test_velocity_control test_smooth_movement ik_fk_validation_test simple_kinematics_test kinematics_validation_test collision_diagnostics_test simple_dh_test simple_ik_test jacobian_validation_test
 
@@ -20,16 +20,16 @@ model_test: model_test.cpp ../src/math_utils.cpp ../src/robot_model.cpp
 pose_controller_test: pose_controller_test.cpp ../src/pose_controller.cpp ../src/robot_model.cpp ../src/math_utils.cpp ../src/pose_config_factory.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
-walk_controller_test: walk_controller_test.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/robot_model.cpp ../src/velocity_limits.cpp ../src/math_utils.cpp
+walk_controller_test: walk_controller_test.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/robot_model.cpp ../src/velocity_limits.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
-admittance_controller_test: admittance_controller_test.cpp ../src/admittance_controller.cpp ../src/robot_model.cpp ../src/math_utils.cpp
+admittance_controller_test: admittance_controller_test.cpp ../src/admittance_controller.cpp ../src/robot_model.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
-locomotion_system_test: locomotion_system_test.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/cartesian_velocity_controller.cpp ../src/math_utils.cpp
+locomotion_system_test: locomotion_system_test.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/cartesian_velocity_controller.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
-state_controller_test: state_controller_test.cpp ../src/state_controller.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/cartesian_velocity_controller.cpp ../src/math_utils.cpp
+state_controller_test: state_controller_test.cpp ../src/state_controller.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/cartesian_velocity_controller.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
 tripod_gait_sim_test: tripod_gait_sim_test.cpp ../src/state_controller.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/cartesian_velocity_controller.cpp ../src/math_utils.cpp ../src/pose_config_factory.cpp ../src/workspace_validator.cpp
@@ -38,7 +38,7 @@ tripod_gait_sim_test: tripod_gait_sim_test.cpp ../src/state_controller.cpp ../sr
 height_range_test: height_range_test.cpp ../src/robot_model.cpp ../src/math_utils.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
-geometry_test: geometry_test.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/cartesian_velocity_controller.cpp ../src/math_utils.cpp
+geometry_test: geometry_test.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/cartesian_velocity_controller.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
 ik_fk_validation_test: ik_fk_validation_test.cpp ../src/robot_model.cpp ../src/math_utils.cpp
@@ -65,28 +65,28 @@ edge_case_analysis: edge_case_analysis.cpp ../src/math_utils.cpp ../src/robot_mo
 angle_normalization_test: angle_normalization_test.cpp ../src/math_utils.cpp ../src/robot_model.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
-terrain_adaptation_test: terrain_adaptation_test.cpp ../src/terrain_adaptation.cpp ../src/walk_controller.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/velocity_limits.cpp ../src/math_utils.cpp
+terrain_adaptation_test: terrain_adaptation_test.cpp ../src/terrain_adaptation.cpp ../src/walk_controller.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/velocity_limits.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
-fsr_threshold_test: fsr_threshold_test.cpp ../src/terrain_adaptation.cpp ../src/walk_controller.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/velocity_limits.cpp ../src/math_utils.cpp
+fsr_threshold_test: fsr_threshold_test.cpp ../src/terrain_adaptation.cpp ../src/walk_controller.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/velocity_limits.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
-velocity_limits_test: velocity_limits_test.cpp ../src/velocity_limits.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/robot_model.cpp ../src/math_utils.cpp
+velocity_limits_test: velocity_limits_test.cpp ../src/velocity_limits.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/robot_model.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
-state_controller_runtime_test: state_controller_runtime_test.cpp ../src/state_controller.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/cartesian_velocity_controller.cpp ../src/math_utils.cpp
+state_controller_runtime_test: state_controller_runtime_test.cpp ../src/state_controller.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/cartesian_velocity_controller.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
-openshc_equivalent_features_test: openshc_equivalent_features_test.cpp ../src/walkspace_analyzer.cpp ../src/manual_pose_controller.cpp ../src/admittance_controller.cpp ../src/imu_auto_pose.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/robot_model.cpp ../src/velocity_limits.cpp ../src/math_utils.cpp
+openshc_equivalent_features_test: openshc_equivalent_features_test.cpp ../src/walkspace_analyzer.cpp ../src/manual_pose_controller.cpp ../src/admittance_controller.cpp ../src/imu_auto_pose.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/robot_model.cpp ../src/velocity_limits.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
-full_feature_sim_test: full_feature_sim_test.cpp ../src/state_controller.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/manual_pose_controller.cpp ../src/imu_auto_pose.cpp ../src/walkspace_analyzer.cpp ../src/cartesian_velocity_controller.cpp ../src/math_utils.cpp
+full_feature_sim_test: full_feature_sim_test.cpp ../src/state_controller.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/manual_pose_controller.cpp ../src/imu_auto_pose.cpp ../src/walkspace_analyzer.cpp ../src/cartesian_velocity_controller.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
-test_metachronal_adaptive_gaits: test_metachronal_adaptive_gaits.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/cartesian_velocity_controller.cpp ../src/math_utils.cpp
+test_metachronal_adaptive_gaits: test_metachronal_adaptive_gaits.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/cartesian_velocity_controller.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
-final_validation_test: final_validation_test.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/cartesian_velocity_controller.cpp ../src/math_utils.cpp
+final_validation_test: final_validation_test.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/cartesian_velocity_controller.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
 quaternion_pose_system_test: quaternion_pose_system_test.cpp ../src/pose_controller.cpp ../src/manual_pose_controller.cpp ../src/robot_model.cpp ../src/math_utils.cpp
@@ -107,16 +107,16 @@ cruise_control_comprehensive_test: cruise_control_comprehensive_test.cpp $(SOURC
 absolute_positioning_compile_test: absolute_positioning_compile_test.cpp ../src/imu_auto_pose.cpp ../src/robot_model.cpp ../src/manual_pose_controller.cpp ../src/pose_controller.cpp ../src/math_utils.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
-enhanced_imu_integration_test: enhanced_imu_integration_test.cpp ../src/terrain_adaptation.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/cartesian_velocity_controller.cpp ../src/math_utils.cpp
+enhanced_imu_integration_test: enhanced_imu_integration_test.cpp ../src/terrain_adaptation.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/cartesian_velocity_controller.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
-admittance_derivatives_test: admittance_derivatives_test.cpp ../src/admittance_controller.cpp ../src/robot_model.cpp ../src/math_utils.cpp
+admittance_derivatives_test: admittance_derivatives_test.cpp ../src/admittance_controller.cpp ../src/robot_model.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
-test_velocity_control: test_velocity_control.cpp ../src/cartesian_velocity_controller.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/math_utils.cpp
+test_velocity_control: test_velocity_control.cpp ../src/cartesian_velocity_controller.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
-test_smooth_movement: test_smooth_movement.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/cartesian_velocity_controller.cpp ../src/math_utils.cpp
+test_smooth_movement: test_smooth_movement.cpp ../src/locomotion_system.cpp ../src/robot_model.cpp ../src/pose_controller.cpp ../src/walk_controller.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/cartesian_velocity_controller.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
 enhanced_kinematics_test: enhanced_kinematics_test.cpp ../src/robot_model.cpp ../src/math_utils.cpp


### PR DESCRIPTION
## Summary
- include `workspace_validator.cpp` in test builds so modules link

## Testing
- `make locomotion_system_test` *(fails: no matching function for call to `LocomotionSystem::initialize`)*

------
https://chatgpt.com/codex/tasks/task_e_6864c33984c88323b4a28d4b37c198f2