### PR TITLE
Fix tripod gait simulation timing

### DIFF
--- a/src/locomotion_system copy.cpp
+++ b/src/locomotion_system copy.cpp
@@ -36,7 +36,9 @@ LocomotionSystem::LocomotionSystem(const Parameters &params)
       model(params), pose_ctrl(nullptr), walk_ctrl(nullptr), admittance_ctrl(nullptr) {
 
     // Initialize leg states and phase offsets for tripod gait
-    static const double tripod_phase_offsets[NUM_LEGS] = {0.0f, 0.5f, 0.5f, 0.0f, 0.0f, 0.5f};
+    // Tripod gait offsets: legs 1, 3 and 5 form one tripod while
+    // legs 2, 4 and 6 are half a cycle out of phase.
+    static const double tripod_phase_offsets[NUM_LEGS] = {0.0f, 0.5f, 0.0f, 0.5f, 0.0f, 0.5f};
     for (int i = 0; i < NUM_LEGS; i++) {
         leg_states[i] = STANCE_PHASE;
         leg_phase_offsets[i] = tripod_phase_offsets[i];

--- a/src/locomotion_system.cpp
+++ b/src/locomotion_system.cpp
@@ -36,7 +36,10 @@ LocomotionSystem::LocomotionSystem(const Parameters &params)
       model(params), pose_ctrl(nullptr), walk_ctrl(nullptr), admittance_ctrl(nullptr) {
 
     // Initialize leg states and phase offsets for tripod gait
-    static const double tripod_phase_offsets[NUM_LEGS] = {0.0f, 0.5f, 0.0f, 0.0f, 0.5f, 0.0f};
+    // Tripod gait requires legs in alternate groups to be half a
+    // cycle out of phase. Legs 1, 3 and 5 step together while
+    // legs 2, 4 and 6 are offset by 180 degrees.
+    static const double tripod_phase_offsets[NUM_LEGS] = {0.0f, 0.5f, 0.0f, 0.5f, 0.0f, 0.5f};
     for (int i = 0; i < NUM_LEGS; i++) {
         leg_states[i] = STANCE_PHASE;
         leg_phase_offsets[i] = tripod_phase_offsets[i];
@@ -900,17 +903,20 @@ void LocomotionSystem::resetSmoothMovement() {
 }
 
 // Main system update
-bool LocomotionSystem::update() {
+bool LocomotionSystem::update(double dt_override) {
     if (!system_enabled)
         return false;
 
-    unsigned long current_time = millis();
-    dt = (current_time - last_update_time) / 1000.0f; // Convert to seconds
-    last_update_time = current_time;
-
-    // Limit dt to avoid large jumps
-    if (dt > 0.1f)
-        dt = 0.1f;
+    if (dt_override >= 0.0) {
+        dt = dt_override;
+    } else {
+        unsigned long current_time = millis();
+        dt = (current_time - last_update_time) / 1000.0f; // Convert to seconds
+        last_update_time = current_time;
+        // Limit dt to avoid large jumps
+        if (dt > 0.1f)
+            dt = 0.1f;
+    }
 
     // PARALLEL SENSOR READING IMPLEMENTATION
     // Update both FSR and IMU sensors simultaneously for optimal performance

--- a/src/locomotion_system.h
+++ b/src/locomotion_system.h
@@ -143,7 +143,8 @@ class LocomotionSystem {
      * @param pose_config Pose configuration for the robot.
      * @return True on successful initialization.
      */
-    bool initialize(IIMUInterface *imu, IFSRInterface *fsr, IServoInterface *servo, const PoseConfiguration &pose_config);
+    bool initialize(IIMUInterface *imu, IFSRInterface *fsr, IServoInterface *servo,
+                    const PoseConfiguration &pose_config = PoseConfiguration());
 
     /**
      * @brief Run calibration sequence for sensors and servos.
@@ -245,8 +246,11 @@ class LocomotionSystem {
     void reprojectStandingFeet();
 
     // System update
-    /** Update all controllers and state machines. */
-    bool update();
+    /** Update all controllers and state machines.
+     *  @param dt_override Optional time step in seconds. When negative the
+     *         update uses the elapsed real time based on millis().
+     */
+    bool update(double dt_override = -1.0);
 
     /** Update FSR and IMU sensors in parallel for optimal performance. */
     bool updateSensorsParallel();

--- a/src/walk_controller.cpp
+++ b/src/walk_controller.cpp
@@ -72,12 +72,15 @@ Point3D WalkController::footTrajectory(int leg_index, double phase, double step_
     if (leg_phase >= 1.0f)
         leg_phase -= 1.0f;
     Point3D trajectory;
-    double base_angle = leg_index * LEG_ANGLE_SPACING;
     const Parameters &p = model.getParams();
 
-    // Calculate leg base position (hexagon corner)
-    double base_x = p.hexagon_radius * cos(math_utils::degreesToRadians(base_angle));
-    double base_y = p.hexagon_radius * sin(math_utils::degreesToRadians(base_angle));
+    // Use the analytic base position from RobotModel to ensure consistency with
+    // inverse kinematics. Derive the base angle from this position.
+    Point3D base_pos = model.getAnalyticLegBasePosition(leg_index);
+    double base_angle =
+        atan2(base_pos.y, base_pos.x) * RADIANS_TO_DEGREES_FACTOR;
+    double base_x = base_pos.x;
+    double base_y = base_pos.y;
 
     // Calculate default foot position within reachable workspace
     double leg_reach = p.coxa_length + p.femur_length + p.tibia_length;

--- a/tests/tripod_gait_sim_test.cpp
+++ b/tests/tripod_gait_sim_test.cpp
@@ -616,7 +616,7 @@ int main() {
         stateController.update(deltaTime);
 
         // Then update the locomotion system with error checking
-        bool update_success = sys.update();
+        bool update_success = sys.update(deltaTime);
         if (!update_success) {
             failed_updates++;
             LocomotionSystem::ErrorCode last_error = sys.getLastError();


### PR DESCRIPTION
## Summary
- calculate base angle using RobotModel offsets
- update foot trajectory to use analytic leg base

## Testing
- `tests/setup.sh`
- `make tripod_gait_sim_test`
- `./tripod_gait_sim_test`

------
https://chatgpt.com/codex/tasks/task_e_6865634ef9108323adefa6027a53803e