### PR TITLE
Refactor kinematics to use radians

### DIFF
--- a/src/leg.cpp
+++ b/src/leg.cpp
@@ -1,14 +1,14 @@
 #include "leg.h"
 #include "hexamotion_constants.h"
 
-// Base angle offsets for each leg (60° apart)
+// Base angle offsets for each leg (60° apart, radians)
 const double BASE_THETA_OFFSETS[NUM_LEGS] = {
-    0.0,    // Leg 0: Front right
-    60.0,   // Leg 1: Middle right
-    120.0,  // Leg 2: Back right
-    180.0,  // Leg 3: Back left
-    240.0,  // Leg 4: Middle left
-    300.0   // Leg 5: Front left
+    0.0 * DEGREES_TO_RADIANS_FACTOR,    // Leg 0: Front right
+    60.0 * DEGREES_TO_RADIANS_FACTOR,   // Leg 1: Middle right
+    120.0 * DEGREES_TO_RADIANS_FACTOR,  // Leg 2: Back right
+    180.0 * DEGREES_TO_RADIANS_FACTOR,  // Leg 3: Back left
+    240.0 * DEGREES_TO_RADIANS_FACTOR,  // Leg 4: Middle left
+    300.0 * DEGREES_TO_RADIANS_FACTOR   // Leg 5: Front left
 };
 
 Leg::Leg(int leg_id, const Parameters &params)
@@ -265,16 +265,16 @@ void Leg::initializeDHParameters(const Parameters &params) {
     dh_parameters_[0][3] = BASE_THETA_OFFSETS[leg_id_]; // theta0 (fixed)
 
     // Coxa joint (row 1)
-    dh_parameters_[1][0] = 0.0;   // a1
-    dh_parameters_[1][1] = 90.0;  // alpha1 (+90°)
-    dh_parameters_[1][2] = 0.0;   // d1
-    dh_parameters_[1][3] = 0.0;   // theta1 offset
+    dh_parameters_[1][0] = 0.0;                          // a1
+    dh_parameters_[1][1] = 90.0 * DEGREES_TO_RADIANS_FACTOR;  // alpha1 (+90°)
+    dh_parameters_[1][2] = 0.0;                          // d1
+    dh_parameters_[1][3] = 0.0;                          // theta1 offset
 
     // Femur joint (row 2)
-    dh_parameters_[2][0] = params.coxa_length; // a2 = coxa length
-    dh_parameters_[2][1] = 90.0;               // alpha2 (+90°)
-    dh_parameters_[2][2] = 0.0;                // d2
-    dh_parameters_[2][3] = 0.0;                // theta2 offset
+    dh_parameters_[2][0] = params.coxa_length;                   // a2 = coxa length
+    dh_parameters_[2][1] = 90.0 * DEGREES_TO_RADIANS_FACTOR;     // alpha2 (+90°)
+    dh_parameters_[2][2] = 0.0;                                  // d2
+    dh_parameters_[2][3] = 0.0;                                  // theta2 offset
 
     // Tibia joint (row 3)
     dh_parameters_[3][0] = params.femur_length; // a3 = femur length
@@ -285,7 +285,7 @@ void Leg::initializeDHParameters(const Parameters &params) {
 
 void Leg::calculateBasePosition(const Parameters &params) {
     // Calculate leg base position in world coordinates
-    double angle_rad = math_utils::degreesToRadians(BASE_THETA_OFFSETS[leg_id_]);
+    double angle_rad = BASE_THETA_OFFSETS[leg_id_];
     base_position_.x = params.hexagon_radius * cos(angle_rad);
     base_position_.y = params.hexagon_radius * sin(angle_rad);
     base_position_.z = 0.0; // Base is at ground level

--- a/src/locomotion_system.cpp
+++ b/src/locomotion_system.cpp
@@ -264,9 +264,9 @@ bool LocomotionSystem::setLegJointAngles(int leg, const JointAngles &q) {
     double tibia_speed = velocity_controller ? velocity_controller->getServoSpeed(leg, 2) : params.default_servo_speed;
 
     // Apply sign inversion/preservation per servo using params.angle_sign_* (adjust left/right or above/below servo orientation)
-    double servo_coxa = clamped_angles.coxa * params.angle_sign_coxa;
-    double servo_femur = clamped_angles.femur * params.angle_sign_femur;
-    double servo_tibia = clamped_angles.tibia * params.angle_sign_tibia;
+    double servo_coxa = clamped_angles.coxa * params.angle_sign_coxa * RADIANS_TO_DEGREES_FACTOR;
+    double servo_femur = clamped_angles.femur * params.angle_sign_femur * RADIANS_TO_DEGREES_FACTOR;
+    double servo_tibia = clamped_angles.tibia * params.angle_sign_tibia * RADIANS_TO_DEGREES_FACTOR;
     servo_interface->setJointAngleAndSpeed(leg, 0, servo_coxa, coxa_speed);
     servo_interface->setJointAngleAndSpeed(leg, 1, servo_femur, femur_speed);
     servo_interface->setJointAngleAndSpeed(leg, 2, servo_tibia, tibia_speed);

--- a/src/robot_model.h
+++ b/src/robot_model.h
@@ -284,7 +284,7 @@ struct Pose {
 };
 
 /**
- * @brief Joint angles for a single leg in degrees.
+ * @brief Joint angles for a single leg in radians.
  */
 struct JointAngles {
     double coxa, femur, tibia;
@@ -491,8 +491,8 @@ class RobotModel {
     bool checkJointLimits(int leg, const JointAngles &q) const;
     /** Clamp angle within limits. */
     double constrainAngle(double angle, double min_angle, double max_angle) const;
-    /** Normalize angle to [-180,180] degrees. */
-    double normalizeAngle(double angle_deg) const;
+    /** Normalize angle to [-pi, pi] radians. */
+    double normalizeAngle(double angle_rad) const;
     /** Validate parameter consistency. */
     bool validate() const;
     /**
@@ -690,7 +690,7 @@ class RobotModel {
     std::array<Point3D, NUM_LEGS> getSymmetricStancePositionsGlobalCoordinates(double stance_radius, double stance_height) const;
 
   private:
-    const Parameters &params;
+    Parameters params;
     // DH parameter table: [leg][joint][param] where param = [a, alpha, d, theta_offset]
     // The first entry stores the fixed base transform for the leg
     double dh_transforms[NUM_LEGS][DOF_PER_LEG + 1][4];


### PR DESCRIPTION
## Summary
- store base offsets and DH parameters in radians
- convert parameter angles to radians once when constructing the robot model
- remove degree conversions within IK/FK calculations
- output servo commands in degrees for compatibility

## Testing
- `cd tests && ./setup.sh`
- `make`
- `./model_test`


------
https://chatgpt.com/codex/tasks/task_e_686ab03d70c88323a9bb295b78091c83