### PR TITLE
Add standing pose setup to walk_controller_test

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -20,7 +20,7 @@ model_test: model_test.cpp ../src/math_utils.cpp ../src/robot_model.cpp
 pose_controller_test: pose_controller_test.cpp ../src/body_pose_controller.cpp ../src/robot_model.cpp ../src/math_utils.cpp ../src/body_pose_config_factory.cpp ../src/leg.cpp ../src/leg_poser.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
-walk_controller_test: walk_controller_test.cpp ../src/walk_controller.cpp ../src/leg_stepper.cpp ../src/terrain_adaptation.cpp ../src/robot_model.cpp ../src/velocity_limits.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp ../src/leg.cpp ../src/walkspace_analyzer.cpp ../src/gait_config_factory.cpp ../src/body_pose_config_factory.cpp
+walk_controller_test: walk_controller_test.cpp ../src/walk_controller.cpp ../src/leg_stepper.cpp ../src/terrain_adaptation.cpp ../src/robot_model.cpp ../src/velocity_limits.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp ../src/leg.cpp ../src/walkspace_analyzer.cpp ../src/gait_config_factory.cpp ../src/body_pose_config_factory.cpp ../src/body_pose_controller.cpp ../src/leg_poser.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
 walk_controller_validation_test: walk_controller_validation_test.cpp ../src/walk_controller.cpp ../src/leg_stepper.cpp ../src/terrain_adaptation.cpp ../src/robot_model.cpp ../src/velocity_limits.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp ../src/leg.cpp ../src/walkspace_analyzer.cpp


### PR DESCRIPTION
## Summary
- refactor walk_controller_test to start from a standing pose created with body_pose_config_factory
- validate start and end of generated trajectory
- link body_pose_controller and leg_poser in Makefile

## Testing
- `./setup.sh`
- `make walk_controller_test`
- `./walk_controller_test`

------
https://chatgpt.com/codex/tasks/task_e_686d5bc0a9448323ab10e7a98cc6500e