### PR TITLE
Fix tripod gait phase computation

### DIFF
--- a/src/leg_stepper.cpp
+++ b/src/leg_stepper.cpp
@@ -53,9 +53,10 @@ void LegStepper::updateStepState(const StepCycle& step) {
     if (step_state_ == STEP_FORCE_STOP) {
         return;
     }
-    if (phase_ >= step.swing_start_ && phase_ < step.swing_end_ && step_state_ != STEP_FORCE_STANCE) {
+    if (phase_ >= step.swing_start_ && phase_ < step.swing_end_ &&
+        step_state_ != STEP_FORCE_STANCE) {
         step_state_ = STEP_SWING;
-    } else if (phase_ < step.stance_end_ || phase_ >= step.stance_start_) {
+    } else {
         step_state_ = STEP_STANCE;
     }
 }

--- a/src/locomotion_system.cpp
+++ b/src/locomotion_system.cpp
@@ -731,7 +731,8 @@ bool LocomotionSystem::update() {
             // Use leg stepper to determine phase
             auto leg_stepper = walk_ctrl->getLegStepper(i);
             if (leg_stepper) {
-                double phase = leg_stepper->getPhase() / 100.0; // Use fixed period for phase calculation
+                double phase = static_cast<double>(leg_stepper->getPhase()) /
+                               static_cast<double>(walk_ctrl->getStepCycle().period_);
                 if (legs[i].shouldBeInStance(phase, stance_duration)) {
                     legs[i].setStepPhase(STANCE_PHASE);
                 } else {
@@ -899,7 +900,8 @@ void LocomotionSystem::updateLegStates() {
             // Use leg stepper to determine phase
             auto leg_stepper = walk_ctrl->getLegStepper(i);
             if (leg_stepper) {
-                double phase = leg_stepper->getPhase() / 100.0; // Use fixed period for phase calculation
+                double phase = static_cast<double>(leg_stepper->getPhase()) /
+                               static_cast<double>(walk_ctrl->getStepCycle().period_);
                 if (legs[i].shouldBeInStance(phase, walk_ctrl->getStanceDuration())) {
                     legs[i].setStepPhase(STANCE_PHASE);
                 } else {
@@ -938,7 +940,8 @@ void LocomotionSystem::updateLegStates() {
         // Check if leg should be in swing based on gait phase
         auto leg_stepper = walk_ctrl->getLegStepper(i);
         if (leg_stepper) {
-            double phase = leg_stepper->getPhase() / 100.0; // Use fixed period for phase calculation
+            double phase = static_cast<double>(leg_stepper->getPhase()) /
+                           static_cast<double>(walk_ctrl->getStepCycle().period_);
             bool should_be_swinging = legs[i].shouldBeInSwing(phase, walk_ctrl->getStanceDuration());
 
             if (should_be_swinging && legs[i].getStepPhase() == STANCE_PHASE) {


### PR DESCRIPTION
## Summary
- correct step phase transitions in `LegStepper`
- normalize phase calculation in `LocomotionSystem`
- compute leg phase offsets relative to gait period in `WalkController`

## Testing
- `cd tests && ./setup.sh`
- `make tripod_gait_sim_test`
- `./tripod_gait_sim_test`

------
https://chatgpt.com/codex/tasks/task_e_686d6216caf8832392532be8ee65d887