### PR TITLE
Enable Y-axis rotations in DH model

### DIFF
--- a/src/math_utils.cpp
+++ b/src/math_utils.cpp
@@ -94,11 +94,35 @@ Eigen::Matrix<T, 4, 4> dhTransform(T a, T alpha, T d, T theta) {
     return transform;
 }
 
+template <typename T>
+Eigen::Matrix<T, 4, 4> dhTransformY(T a, T alpha, T d, T theta) {
+    Eigen::Matrix<T, 4, 4> R_y = Eigen::Matrix<T, 4, 4>::Identity();
+    R_y.block(0, 0, 3, 3) =
+        Eigen::AngleAxis<T>(theta, Eigen::Matrix<T, 3, 1>::UnitY()).toRotationMatrix();
+
+    Eigen::Matrix<T, 4, 4> T_z = Eigen::Matrix<T, 4, 4>::Identity();
+    T_z(2, 3) = d;
+
+    Eigen::Matrix<T, 4, 4> T_x = Eigen::Matrix<T, 4, 4>::Identity();
+    T_x(0, 3) = a;
+
+    Eigen::Matrix<T, 4, 4> R_x = Eigen::Matrix<T, 4, 4>::Identity();
+    R_x.block(0, 0, 3, 3) =
+        Eigen::AngleAxis<T>(alpha, Eigen::Matrix<T, 3, 1>::UnitX()).toRotationMatrix();
+
+    return R_y * T_z * T_x * R_x;
+}
+
 // Explicit instantiations for common precisions
 template Eigen::Matrix4d dhTransform<double>(double, double, double, double);
+template Eigen::Matrix4d dhTransformY<double>(double, double, double, double);
 
 Eigen::Matrix4d dhTransform(double a, double alpha, double d, double theta) {
     return dhTransform<double>(a, alpha, d, theta);
+}
+
+Eigen::Matrix4d dhTransformY(double a, double alpha, double d, double theta) {
+    return dhTransformY<double>(a, alpha, d, theta);
 }
 
 Eigen::Vector3d quaternionToEuler(const Eigen::Vector4d &quaternion) {

--- a/src/math_utils.h
+++ b/src/math_utils.h
@@ -67,8 +67,15 @@ Eigen::Vector4d quaternionSlerp(const Eigen::Vector4d &q1, const Eigen::Vector4d
 template <typename T>
 Eigen::Matrix<T, 4, 4> dhTransform(T a, T alpha, T d, T theta);
 
+/** Generic DH transform with rotation around the Y axis (angles in radians). */
+template <typename T>
+Eigen::Matrix<T, 4, 4> dhTransformY(T a, T alpha, T d, T theta);
+
 /** Float-specialized DH transform for backwards compatibility. */
 Eigen::Matrix4d dhTransform(double a, double alpha, double d, double theta);
+
+/** Float-specialized DH transform with Y-axis rotation. */
+Eigen::Matrix4d dhTransformY(double a, double alpha, double d, double theta);
 
 /**
  * @brief Evaluate a quadratic Bezier curve.


### PR DESCRIPTION
## Summary
- support DH transforms that rotate around the Y axis
- update default DH parameters to match analytic leg model
- build leg transforms using Y-axis DH rows for femur and tibia
- compute Jacobians numerically from DH-based forward kinematics

## Testing
- `make simple_dh_test simple_ik_test dh_vs_analytic_test`
- `./simple_dh_test`
- `./simple_ik_test`
- `./dh_vs_analytic_test`


------
https://chatgpt.com/codex/tasks/task_e_687178800d248323aa2958283734e4b1