### PR TITLE
Enable Y-axis rotations in DH model

### DIFF
--- a/src/math_utils.cpp
+++ b/src/math_utils.cpp
@@ -94,11 +94,37 @@ Eigen::Matrix<T, 4, 4> dhTransform(T a, T alpha, T d, T theta) {
     return transform;
 }
 
+template <typename T>
+Eigen::Matrix<T, 4, 4> dhTransformY(T a, T alpha, T d, T theta) {
+    // Similar to dhTransform but rotates around the Y axis. This matches
+    // the analytic model where femur and tibia joints pitch about Y.
+    Eigen::Matrix<T, 4, 4> R_y = Eigen::Matrix<T, 4, 4>::Identity();
+    R_y.block(0, 0, 3, 3) =
+        Eigen::AngleAxis<T>(theta, Eigen::Matrix<T, 3, 1>::UnitY()).toRotationMatrix();
+
+    Eigen::Matrix<T, 4, 4> T_z = Eigen::Matrix<T, 4, 4>::Identity();
+    T_z(2, 3) = d;
+
+    Eigen::Matrix<T, 4, 4> T_x = Eigen::Matrix<T, 4, 4>::Identity();
+    T_x(0, 3) = a;
+
+    Eigen::Matrix<T, 4, 4> R_x = Eigen::Matrix<T, 4, 4>::Identity();
+    R_x.block(0, 0, 3, 3) =
+        Eigen::AngleAxis<T>(alpha, Eigen::Matrix<T, 3, 1>::UnitX()).toRotationMatrix();
+
+    return R_y * T_z * T_x * R_x;
+}
+
 // Explicit instantiations for common precisions
 template Eigen::Matrix4d dhTransform<double>(double, double, double, double);
+template Eigen::Matrix4d dhTransformY<double>(double, double, double, double);
 
 Eigen::Matrix4d dhTransform(double a, double alpha, double d, double theta) {
     return dhTransform<double>(a, alpha, d, theta);
+}
+
+Eigen::Matrix4d dhTransformY(double a, double alpha, double d, double theta) {
+    return dhTransformY<double>(a, alpha, d, theta);
 }
 
 Eigen::Vector3d quaternionToEuler(const Eigen::Vector4d &quaternion) {

--- a/src/math_utils.h
+++ b/src/math_utils.h
@@ -67,8 +67,21 @@ Eigen::Vector4d quaternionSlerp(const Eigen::Vector4d &q1, const Eigen::Vector4d
 template <typename T>
 Eigen::Matrix<T, 4, 4> dhTransform(T a, T alpha, T d, T theta);
 
+/**
+ * @brief Generic DH transform rotating about the Y axis.
+ *
+ * This variant is used for joints that pitch instead of yaw so the
+ * kinematic chain matches the analytic leg model.
+ * @tparam T Floating point type.
+ */
+template <typename T>
+Eigen::Matrix<T, 4, 4> dhTransformY(T a, T alpha, T d, T theta);
+
 /** Float-specialized DH transform for backwards compatibility. */
 Eigen::Matrix4d dhTransform(double a, double alpha, double d, double theta);
+
+/** Float-specialized DH transform with Y-axis rotation. */
+Eigen::Matrix4d dhTransformY(double a, double alpha, double d, double theta);
 
 /**
  * @brief Evaluate a quadratic Bezier curve.

--- a/src/robot_model.cpp
+++ b/src/robot_model.cpp
@@ -37,32 +37,34 @@ RobotModel::RobotModel(const Parameters &p) : params(p) {
 
 void RobotModel::initializeDH() {
 
-    // Initialize default DH parameters if custom parameters are not used
+    // Initialize default DH parameters if custom parameters are not used.
+    // The analytic model pitches the femur and tibia about the Y axis. We
+    // replicate that behavior by later applying dhTransformY on rows 2 and 3.
     if (!params.use_custom_dh_parameters) {
         for (int l = 0; l < NUM_LEGS; ++l) {
-            // ── Fila 0: base rígida ───────────────────────────
+            // ── Row 0: fixed base ────────────────────────────
             dh_transforms[l][0][0] = params.hexagon_radius; // a0 = 200mm
             dh_transforms[l][0][1] = 0.0f;                  // alpha0
             dh_transforms[l][0][2] = 0.0f;                  // d1
-            dh_transforms[l][0][3] = BASE_THETA_OFFSETS[l]; // θ0  (fijo)
+            dh_transforms[l][0][3] = BASE_THETA_OFFSETS[l]; // θ0 (fixed)
 
-            // ── Fila 1: servo yaw ─────────────────────────────
-            dh_transforms[l][1][0] = 0.0f;                              // a1
-            dh_transforms[l][1][1] = 90.0f * DEGREES_TO_RADIANS_FACTOR; // alpha1 (+90°)
-            dh_transforms[l][1][2] = 0.0f;                              // d2
-            dh_transforms[l][1][3] = 0.0f;                              // θ1 offset (suma ψ)
+            // ── Row 1: yaw servo + coxa ─────────────────────
+            dh_transforms[l][1][0] = params.coxa_length;    // a1 = 50
+            dh_transforms[l][1][1] = 0.0f;                  // alpha1
+            dh_transforms[l][1][2] = 0.0f;                  // d2
+            dh_transforms[l][1][3] = 0.0f;                  // θ1 offset (adds ψ)
 
-            // ── Fila 2: servo hip-pitch + coxa ───────────────
-            dh_transforms[l][2][0] = params.coxa_length;                // a2 = 50
-            dh_transforms[l][2][1] = 90.0f * DEGREES_TO_RADIANS_FACTOR; // alpha2 (+90°)
-            dh_transforms[l][2][2] = 0.0f;                              // d3
-            dh_transforms[l][2][3] = 0.0f;                              // θ2 offset (suma θ₁)
+            // ── Row 2: femur pitch servo ────────────────────
+            dh_transforms[l][2][0] = params.femur_length;   // a2 = 101
+            dh_transforms[l][2][1] = 0.0f;                  // alpha2
+            dh_transforms[l][2][2] = 0.0f;                  // d3
+            dh_transforms[l][2][3] = 0.0f;                  // θ2 offset (adds θ₁)
 
-            // ── Fila 3: servo knee-pitch + tibia ─────────────
-            dh_transforms[l][3][0] = params.femur_length; // a3 = 101
-            dh_transforms[l][3][1] = 0.0f;                // alpha3
-            dh_transforms[l][3][2] = params.tibia_length; // d4 = 208
-            dh_transforms[l][3][3] = 0.0f;                // θ3 offset (suma θ₂)
+            // ── Row 3: knee pitch servo + tibia ─────────────
+            dh_transforms[l][3][0] = 0.0f;                  // a3
+            dh_transforms[l][3][1] = 0.0f;                  // alpha3
+            dh_transforms[l][3][2] = -params.tibia_length;  // d4 = -208
+            dh_transforms[l][3][3] = 0.0f;                  // θ3 offset (adds θ₂)
         }
     } else {
         // Copy custom DH parameters provided in params.dh_parameters
@@ -239,46 +241,53 @@ Eigen::Matrix4d RobotModel::legTransform(int leg_index, const JointAngles &q) co
 
     const double joint_rad[DOF_PER_LEG] = {q.coxa, q.femur, q.tibia};
 
-    // Apply joint transforms
+    // Apply joint transforms.
+    // Femur and tibia joints pitch about the Y axis, so rows 2 and 3 use
+    // dhTransformY instead of the standard Z-axis version.
     for (int j = 1; j <= DOF_PER_LEG; ++j) {
         double a = dh_transforms[leg_index][j][0];      // link length
         double alpha = dh_transforms[leg_index][j][1];  // twist angle
         double d = dh_transforms[leg_index][j][2];      // link offset
         double theta0 = dh_transforms[leg_index][j][3]; // joint offset
         double theta = theta0 + joint_rad[j - 1];       // total joint angle
-        T *= math_utils::dhTransform<double>(a, alpha, d, theta);
+        if (j >= 2) {
+            T *= math_utils::dhTransformY<double>(a, alpha, d, theta);
+        } else {
+            T *= math_utils::dhTransform<double>(a, alpha, d, theta);
+        }
     }
 
     return T;
 }
 
 Eigen::Matrix3d RobotModel::calculateJacobian(int leg, const JointAngles &q, const Point3D &) const {
-    // Calculate Jacobian from DH matrices along the kinematic chain
-    // Based on syropod_highlevel_controller implementation
+    // Numerical Jacobian computation using DH-based forward kinematics
+    const double delta = JACOBIAN_DELTA;
 
-    // Build transforms step by step using DH parameters
-    std::vector<Eigen::Matrix4d> transforms = buildDHTransforms(leg, q);
+    Point3D base = forwardKinematicsGlobalCoordinates(leg, q);
 
-    // End-effector transform
-    Eigen::Matrix4d T_final = transforms[DOF_PER_LEG];
+    JointAngles qd = q;
+    qd.coxa += delta;
+    Point3D p_dx = forwardKinematicsGlobalCoordinates(leg, qd);
 
-    // End-effector position
-    Eigen::Vector3d pe = T_final.block<3, 1>(0, 3);
+    qd = q;
+    qd.femur += delta;
+    Point3D p_dy = forwardKinematicsGlobalCoordinates(leg, qd);
 
-    // Initialize Jacobian matrix (3x3 for position only)
+    qd = q;
+    qd.tibia += delta;
+    Point3D p_dz = forwardKinematicsGlobalCoordinates(leg, qd);
+
     Eigen::Matrix3d jacobian;
-
-    // First joint (base joint) - use standard z-axis
-    Eigen::Vector3d z0(0.0, 0.0, 1.0);
-    Eigen::Vector3d p0 = transforms[0].block<3, 1>(0, 3);
-    jacobian.col(0) = (z0.cross(pe - p0)).cast<double>();
-
-    // Remaining joints
-    for (int j = 1; j < DOF_PER_LEG; ++j) {
-        Eigen::Vector3d zj = transforms[j].block<3, 1>(0, 2); // z-axis of joint j
-        Eigen::Vector3d pj = transforms[j].block<3, 1>(0, 3); // position of joint j
-        jacobian.col(j) = (zj.cross(pe - pj)).cast<double>();
-    }
+    jacobian.col(0) = Eigen::Vector3d((p_dx.x - base.x) / delta,
+                                      (p_dx.y - base.y) / delta,
+                                      (p_dx.z - base.z) / delta);
+    jacobian.col(1) = Eigen::Vector3d((p_dy.x - base.x) / delta,
+                                      (p_dy.y - base.y) / delta,
+                                      (p_dy.z - base.z) / delta);
+    jacobian.col(2) = Eigen::Vector3d((p_dz.x - base.x) / delta,
+                                      (p_dz.y - base.y) / delta,
+                                      (p_dz.z - base.z) / delta);
 
     return jacobian;
 }
@@ -297,15 +306,21 @@ std::vector<Eigen::Matrix4d> RobotModel::buildDHTransforms(int leg, const JointA
 
     const double joint_rad[DOF_PER_LEG] = {q.coxa, q.femur, q.tibia};
 
-    // Build transforms step by step using DH parameters
+    // Build transforms step by step using DH parameters.
+    // As above, pitch joints require the Y-axis transform variant.
     for (int j = 1; j <= DOF_PER_LEG; ++j) {
         double a = dh_transforms[leg][j][0];      // link length
         double alpha = dh_transforms[leg][j][1];  // twist angle
         double d = dh_transforms[leg][j][2];      // link offset
         double theta0 = dh_transforms[leg][j][3]; // joint offset
         double theta = theta0 + joint_rad[j - 1]; // total joint angle
-        transforms[j] = transforms[j - 1] *
-                        math_utils::dhTransform<double>(a, alpha, d, theta);
+        if (j >= 2) {
+            transforms[j] = transforms[j - 1] *
+                            math_utils::dhTransformY<double>(a, alpha, d, theta);
+        } else {
+            transforms[j] = transforms[j - 1] *
+                            math_utils::dhTransform<double>(a, alpha, d, theta);
+        }
     }
 
     return transforms;


### PR DESCRIPTION
## Summary
- support DH transforms that rotate around the Y axis
- update default DH parameters to match analytic leg model
- build leg transforms using Y-axis DH rows for femur and tibia
- compute Jacobians numerically from DH-based forward kinematics
- clarify why Y-axis DH transforms are used

## Testing
- `cd tests && ./setup.sh`
- `make simple_dh_test simple_ik_test`
- `./simple_dh_test`
- `./simple_ik_test`


------
https://chatgpt.com/codex/tasks/task_e_687178800d248323aa2958283734e4b1