### PR TITLE
Add tripod gait stepper test

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -9,7 +9,7 @@ CXXFLAGS=-I../src -I. -I$(EIGEN_PATH) -std=c++17
 
 SOURCES = ../src/math_utils.cpp ../src/robot_model.cpp ../src/body_pose_controller.cpp ../src/walk_controller.cpp ../src/leg_stepper.cpp ../src/terrain_adaptation.cpp ../src/admittance_controller.cpp ../src/velocity_limits.cpp ../src/state_controller.cpp ../src/locomotion_system.cpp ../src/cartesian_velocity_controller.cpp ../src/workspace_validator.cpp ../src/body_pose_config_factory.cpp ../src/body_pose.cpp ../src/leg.cpp ../src/walkspace_analyzer.cpp ../src/leg_poser.cpp ../src/gait_config_factory.cpp
 
-all: math_utils_test pose_controller_test walk_controller_test tripod_gait_sim_test tripod_gait_validation_test quaternion_functions_test kinematics_validation_test simple_dh_test simple_ik_test simple_advanced_ik_test brute_force_workspace_test jacobian_validation_test dh_vs_analytic_test pose_gait_tripod_integration_test trajectory_tip_position_test trajectory_all_legs_test bezier_precision_analysis_test finetune_angles_test
+all: math_utils_test pose_controller_test walk_controller_test tripod_gait_sim_test tripod_gait_validation_test quaternion_functions_test kinematics_validation_test simple_dh_test simple_ik_test simple_advanced_ik_test brute_force_workspace_test jacobian_validation_test dh_vs_analytic_test pose_gait_tripod_integration_test trajectory_tip_position_test trajectory_all_legs_test tripod_gait_stepper_test bezier_precision_analysis_test finetune_angles_test
 
 math_utils_test: math_utils_test.cpp ../src/math_utils.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
@@ -62,10 +62,13 @@ trajectory_tip_position_test: trajectory_tip_position_test.cpp ../src/walk_contr
 trajectory_all_legs_test: trajectory_all_legs_test.cpp ../src/walk_controller.cpp ../src/leg_stepper.cpp ../src/terrain_adaptation.cpp ../src/robot_model.cpp ../src/velocity_limits.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp ../src/leg.cpp ../src/walkspace_analyzer.cpp ../src/gait_config_factory.cpp ../src/body_pose_config_factory.cpp ../src/body_pose_controller.cpp ../src/leg_poser.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
+tripod_gait_stepper_test: tripod_gait_stepper_test.cpp ../src/walk_controller.cpp ../src/leg_stepper.cpp ../src/terrain_adaptation.cpp ../src/robot_model.cpp ../src/velocity_limits.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp ../src/leg.cpp ../src/walkspace_analyzer.cpp ../src/gait_config_factory.cpp ../src/body_pose_config_factory.cpp ../src/body_pose_controller.cpp ../src/leg_poser.cpp
+	$(CXX) $(CXXFLAGS) $^ -o $@
+
 bezier_precision_analysis_test: bezier_precision_analysis_test.cpp ../src/walk_controller.cpp ../src/leg_stepper.cpp ../src/terrain_adaptation.cpp ../src/robot_model.cpp ../src/velocity_limits.cpp ../src/math_utils.cpp ../src/workspace_validator.cpp ../src/leg.cpp ../src/walkspace_analyzer.cpp ../src/gait_config_factory.cpp ../src/body_pose_config_factory.cpp ../src/body_pose_controller.cpp ../src/leg_poser.cpp
 	$(CXX) $(CXXFLAGS) $^ -o $@
 
 clean:
-	rm -f math_utils_test pose_controller_test walk_controller_test tripod_gait_sim_test tripod_gait_validation_test quaternion_functions_test kinematics_validation_test simple_dh_test simple_ik_test simple_advanced_ik_test brute_force_workspace_test jacobian_validation_test dh_vs_analytic_test pose_gait_tripod_integration_test trajectory_tip_position_test trajectory_all_legs_test bezier_precision_analysis_test finetune_angles_test
+	rm -f math_utils_test pose_controller_test walk_controller_test tripod_gait_sim_test tripod_gait_validation_test quaternion_functions_test kinematics_validation_test simple_dh_test simple_ik_test simple_advanced_ik_test brute_force_workspace_test jacobian_validation_test dh_vs_analytic_test pose_gait_tripod_integration_test trajectory_tip_position_test trajectory_all_legs_test tripod_gait_stepper_test bezier_precision_analysis_test finetune_angles_test
 
 

--- a/tests/pose_controller_test.cpp
+++ b/tests/pose_controller_test.cpp
@@ -233,7 +233,7 @@ int main() {
     for (int i = 0; i < NUM_LEGS; i++) {
         legs[i].setStepPhase(STANCE_PHASE);
         Point3D tilted_pos(i * 50.0, i * 30.0, -150.0 + i * 10.0); // Increasing height
-        legs[i].setCurrentTipPositionGlobal(model, tilted_pos);
+        legs[i].setCurrentTipPositionGlobal(tilted_pos);
     }
 
     pc.updateWalkPlanePose(legs);
@@ -249,7 +249,7 @@ int main() {
     for (int i = 0; i < NUM_LEGS; i++) {
         legs[i].setStepPhase(i < 2 ? STANCE_PHASE : SWING_PHASE);
         Point3D test_pos(i * 50.0, i * 30.0, -150.0 + i * 10.0);
-        legs[i].setCurrentTipPositionGlobal(model, test_pos);
+        legs[i].setCurrentTipPositionGlobal(test_pos);
     }
 
     Pose before_insufficient = pc.getWalkPlanePose();
@@ -272,7 +272,7 @@ int main() {
     for (int i = 0; i < NUM_LEGS; i++) {
         legs[i].setStepPhase(STANCE_PHASE);
         Point3D test_pos(i * 50.0, i * 30.0, leg_heights[i]);
-        legs[i].setCurrentTipPositionGlobal(model, test_pos);
+        legs[i].setCurrentTipPositionGlobal(test_pos);
         expected_average += leg_heights[i];
     }
     expected_average /= NUM_LEGS;
@@ -414,7 +414,7 @@ int main() {
 
     for (int i = 0; i < NUM_LEGS; i++) {
         Point3D known_pos(i * 20.0, i * 15.0, known_z_values[i]);
-        legs[i].setCurrentTipPositionGlobal(model, known_pos);
+        legs[i].setCurrentTipPositionGlobal(known_pos);
         legs[i].setStepPhase(STANCE_PHASE);
         expected_average_z += known_z_values[i];
     }

--- a/tests/tripod_gait_stepper_test.cpp
+++ b/tests/tripod_gait_stepper_test.cpp
@@ -1,0 +1,102 @@
+#include "../src/body_pose_config_factory.h"
+#include "../src/body_pose_controller.h"
+#include "../src/gait_config.h"
+#include "../src/gait_config_factory.h"
+#include "../src/leg_stepper.h"
+#include "../src/walkspace_analyzer.h"
+#include "../src/workspace_validator.h"
+#include "test_stubs.h"
+#include <iomanip>
+#include <iostream>
+
+static double toDegrees(double rad) { return rad * 180.0 / M_PI; }
+
+int main() {
+    Parameters p = createDefaultParameters();
+    GaitConfiguration gait = createTripodGaitConfig(p);
+    StepCycle step_cycle = gait.generateStepCycle();
+
+    RobotModel model(p);
+    Leg legs[NUM_LEGS] = {Leg(0, model), Leg(1, model), Leg(2, model),
+                          Leg(3, model), Leg(4, model), Leg(5, model)};
+
+    for (int i = 0; i < NUM_LEGS; ++i) {
+        legs[i].initialize(Pose::Identity());
+        legs[i].updateTipPosition();
+    }
+
+    BodyPoseConfiguration pose_cfg = getDefaultBodyPoseConfig(p);
+    BodyPoseController pose_controller(model, pose_cfg);
+    pose_controller.setWalkPlanePoseEnabled(true);
+    pose_controller.initializeLegPosers(legs);
+    if (!pose_controller.setStandingPose(legs)) {
+        std::cerr << "Error al establecer la posición inicial" << std::endl;
+        return 1;
+    }
+
+    WalkspaceAnalyzer analyzer(model);
+    WorkspaceValidator validator(model);
+    LegStepper steppers[NUM_LEGS] = {
+        LegStepper(0, legs[0].getCurrentTipPositionGlobal(), legs[0], model, &analyzer, &validator),
+        LegStepper(1, legs[1].getCurrentTipPositionGlobal(), legs[1], model, &analyzer, &validator),
+        LegStepper(2, legs[2].getCurrentTipPositionGlobal(), legs[2], model, &analyzer, &validator),
+        LegStepper(3, legs[3].getCurrentTipPositionGlobal(), legs[3], model, &analyzer, &validator),
+        LegStepper(4, legs[4].getCurrentTipPositionGlobal(), legs[4], model, &analyzer, &validator),
+        LegStepper(5, legs[5].getCurrentTipPositionGlobal(), legs[5], model, &analyzer, &validator)};
+
+    for (int i = 0; i < NUM_LEGS; ++i) {
+        steppers[i].setStepCycle(step_cycle);
+        steppers[i].setControlFrequency(gait.control_frequency);
+        steppers[i].setStepClearanceHeight(gait.swing_height);
+        steppers[i].setDefaultTipPose(legs[i].getCurrentTipPositionGlobal());
+        steppers[i].setCurrentTipPose(legs[i].getCurrentTipPositionGlobal());
+        double offset = static_cast<double>(gait.offsets.getForLegIndex(i) * gait.phase_config.phase_offset) /
+                        step_cycle.period_;
+        steppers[i].setPhaseOffset(offset);
+        steppers[i].setDesiredVelocity(Point3D(20.0, 0.0, 0.0), 0.0);
+        steppers[i].updateStride();
+        steppers[i].setStepState(STEP_STANCE);
+    }
+
+    std::cout << "Iter\tPata\tFase\tPosición (x,y,z)\t\tÁngulos (c,f,t)" << std::endl;
+
+    int total_steps = 20;
+    double time_delta = 1.0 / gait.control_frequency;
+    for (int step = 0; step < total_steps; ++step) {
+        int global_phase = step % step_cycle.period_;
+        for (int leg = 0; leg < NUM_LEGS; ++leg) {
+            int offset = gait.offsets.getForLegIndex(leg) * gait.phase_config.phase_offset;
+            int leg_phase = (global_phase + offset) % step_cycle.period_;
+            bool in_swing = leg_phase >= step_cycle.stance_period_;
+            StepState desired_state = in_swing ? STEP_SWING : STEP_STANCE;
+            if (steppers[leg].getStepState() != desired_state) {
+                steppers[leg].setStepState(desired_state);
+                if (desired_state == STEP_SWING)
+                    steppers[leg].initializeSwingPeriod(1);
+            }
+            steppers[leg].updateTipPositionIterative(leg_phase, time_delta, false, false);
+
+            Point3D pos = steppers[leg].getCurrentTipPose();
+            JointAngles prev_angles = legs[leg].getJointAngles();
+            Point3D prev_pos = legs[leg].getCurrentTipPositionGlobal();
+            JointAngles new_angles = model.applyAdvancedIK(leg, prev_pos, pos, prev_angles, time_delta);
+            legs[leg].setJointAngles(new_angles);
+            legs[leg].setStepPhase(in_swing ? SWING_PHASE : STANCE_PHASE);
+        }
+
+        if (step % 5 == 0) {
+            for (int leg = 0; leg < NUM_LEGS; ++leg) {
+                Point3D pos = legs[leg].getCurrentTipPositionGlobal();
+                JointAngles ang = legs[leg].getJointAngles();
+                StepPhase ph = legs[leg].getStepPhase();
+                std::cout << step << "\t" << leg << "\t" << (ph == SWING_PHASE ? "SW" : "ST")
+                          << "\t[" << std::fixed << std::setprecision(1) << pos.x << ", " << pos.y << ", " << pos.z << "]"
+                          << "\t[" << std::setprecision(2) << toDegrees(ang.coxa) << ", "
+                          << toDegrees(ang.femur) << ", " << toDegrees(ang.tibia) << "]" << std::endl;
+            }
+            std::cout << "-------------------------------" << std::endl;
+        }
+    }
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add tripod_gait_stepper_test to validate tripod trajectory without using LocomotionSystem
- update Makefile to build the new test
- fix outdated function calls in pose_controller_test

## Testing
- `./tests/setup.sh`
- `make tripod_gait_stepper_test`
- `./tripod_gait_stepper_test`

------
https://chatgpt.com/codex/tasks/task_e_6883f04110508323912e25cd58950730